### PR TITLE
deployment/contour: use port 80 as the service target port

### DIFF
--- a/deployment/contour/02-service.yaml
+++ b/deployment/contour/02-service.yaml
@@ -16,7 +16,7 @@ spec:
  - port: 80
    name: http
    protocol: TCP
-   targetPort: 8080
+   targetPort: 80
  - port: 443
    name: https
    protocol: TCP


### PR DESCRIPTION
```
We have configured contour to serve http traffic on port 80, but missed
updating the service to reflect this change. Set the target port in the
service accordingly.

Signed-off-by: Alexander Brand <alexbrand09@gmail.com>
```