### PR TITLE
Jenkinsfile for pushing images to GCR

### DIFF
--- a/discovery/Jenkinsfile
+++ b/discovery/Jenkinsfile
@@ -1,0 +1,51 @@
+pipeline {
+    agent {
+        label 'general'
+    }
+
+    options {
+        buildDiscarder(logRotator(numToKeepStr: '10'))
+        disableConcurrentBuilds()
+    }
+
+    environment {
+        REGISTRY = 'gcr.io/heptio-images'
+        IMAGE = 'gcr.io/heptio-images/gimbal-discoverer'
+    }
+
+    stages {
+        stage('Determine version') {
+            steps {
+                script {
+                    if (env.BRANCH_NAME == "master") {
+                        imageRepo = env.REGISTRY
+                        imageName = env.IMAGE
+                        imageVersion = "master"
+                    } else if (env.BRANCH_NAME ==~ /PR-[0-9]+/) {
+                        imageRepo = env.REGISTRY
+                        imageName = env.IMAGE
+                        imageVersion = "${env.GIT_COMMIT[0..6]}"
+                    }
+                }
+            }
+        }
+
+        stage('Build image') {
+            steps {
+                sh("cd discovery && VERSION=${imageVersion} make container")
+            }
+        }
+
+        stage('Push image') {
+            options {
+                timeout(time: 10, unit: 'MINUTES')
+            }
+
+            steps {
+                withCredentials([file(credentialsId: 'heptio-images-gcr', variable: 'GOOGLE_APPLICATION_CREDENTIALS')]) {
+                    sh("docker push ${imageName}:${imageVersion}")
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
I've spoken to @stevesloka privately, but we are deprecating our old Jenkins setup. This means we need to come up with a way to build/push images to our image repository. Moving this work into a Jenkinsfile allows the project to manage that behavior a bit more closely.

This is incredibly basic, and I suspect changes will be made, but this gets the pipeline in place.

Signed-off-by: Curt Micol <asenchi@heptio.com>