### PR TITLE
discoverer: set clustername when creating syncqueue in openstack discoverer

### DIFF
--- a/deployment/gimbal-discoverer/02-openstack-discoverer.yaml
+++ b/deployment/gimbal-discoverer/02-openstack-discoverer.yaml
@@ -5,9 +5,6 @@ metadata:
     app: openstack-discoverer
     cluster: origin
   name: openstack-discoverer
-  annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "8080"
   namespace: gimbal-discovery
 spec:
   selector:
@@ -17,6 +14,9 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
       labels:
         app: openstack-discoverer
         cluster: openstack

--- a/discovery/pkg/k8s/controller.go
+++ b/discovery/pkg/k8s/controller.go
@@ -25,7 +25,6 @@ import (
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
 )
 
 const (
@@ -53,15 +52,8 @@ func NewController(log *logrus.Logger, gimbalKubeClient kubernetes.Interface, ku
 	endpointsInformer := kubeInformerFactory.Core().V1().Endpoints()
 
 	c := &Controller{
-		Logger: log,
-		syncqueue: sync.Queue{
-			KubeClient:  gimbalKubeClient,
-			Logger:      log,
-			Workqueue:   workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "syncqueue"),
-			Threadiness: threadiness,
-			Metrics:     metrics,
-			ClusterName: clusterName,
-		},
+		Logger:          log,
+		syncqueue:       sync.NewQueue(log, clusterName, gimbalKubeClient, threadiness, metrics),
 		servicesSynced:  serviceInformer.Informer().HasSynced,
 		endpointsSynced: endpointsInformer.Informer().HasSynced,
 		clusterName:     clusterName,

--- a/discovery/pkg/openstack/reconciler.go
+++ b/discovery/pkg/openstack/reconciler.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/util/workqueue"
 )
 
 type ProjectLister interface {
@@ -70,13 +69,7 @@ func NewReconciler(clusterName string, gimbalKubeClient kubernetes.Interface, sy
 		ProjectLister:      projectLister,
 		Logger:             log,
 		Metrics:            metrics,
-		syncqueue: sync.Queue{
-			KubeClient:  gimbalKubeClient,
-			Logger:      log,
-			Workqueue:   workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "syncqueue"),
-			Threadiness: queueWorkers,
-			Metrics:     metrics,
-		},
+		syncqueue:          sync.NewQueue(log, clusterName, gimbalKubeClient, queueWorkers, metrics),
 	}
 }
 

--- a/discovery/pkg/sync/queue.go
+++ b/discovery/pkg/sync/queue.go
@@ -42,6 +42,19 @@ type Queue struct {
 	ClusterName string
 }
 
+// NewQueue returns an initialized sync.Queue for syncing resources with a Gimbal cluster.
+func NewQueue(logger *logrus.Logger, clusterName string, kubeClient kubernetes.Interface,
+	threadiness int, metrics localmetrics.DiscovererMetrics) Queue {
+	return Queue{
+		KubeClient:  kubeClient,
+		Logger:      logger,
+		Workqueue:   workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "syncqueue"),
+		Threadiness: threadiness,
+		Metrics:     metrics,
+		ClusterName: clusterName,
+	}
+}
+
 // Action that is added to the queue for processing
 type Action interface {
 	Sync(kube kubernetes.Interface, lm localmetrics.DiscovererMetrics, clusterName string) error


### PR DESCRIPTION
Fixes #51 

```
Also fix annotations on openstack discoverer deployment file.

Signed-off-by: Alexander Brand <alexbrand09@gmail.com>
```