### PR TITLE
SetupSignalHandler changed to secure single execution

### DIFF
--- a/discovery/pkg/signals/signal.go
+++ b/discovery/pkg/signals/signal.go
@@ -19,25 +19,29 @@ package signals
 import (
 	"os"
 	"os/signal"
+	"sync"
 )
 
-var onlyOneSignalHandler = make(chan struct{})
+var (
+	once sync.Once
+	stop = make(chan struct{})
+)
 
 // SetupSignalHandler registered for SIGTERM and SIGINT. A stop channel is returned
 // which is closed on one of these signals. If a second signal is caught, the program
 // is terminated with exit code 1.
 func SetupSignalHandler() (stopCh <-chan struct{}) {
-	close(onlyOneSignalHandler) // panics when called twice
 
-	stop := make(chan struct{})
-	c := make(chan os.Signal, 2)
-	signal.Notify(c, shutdownSignals...)
-	go func() {
-		<-c
-		close(stop)
-		<-c
-		os.Exit(1) // second signal. Exit directly.
-	}()
+	once.Do(func() { //run only once
+		c := make(chan os.Signal, 2)
+		signal.Notify(c, shutdownSignals...)
+		go func() {
+			<-c
+			close(stop)
+			<-c
+			os.Exit(1) // second signal. Exit directly.
+		}()
+	})
 
 	return stop
 }


### PR DESCRIPTION
Although SetupSignalHandler is implemented to panic when called twice, it is possible to secure single execution without panic by using sync.Once

Signed-off-by: kpango <i.can.feel.gravity@gmail.com>