### PR TITLE
discovert/cmd/kubernetes-discoverer: remove constant workingNamespace

### DIFF
--- a/discovery/cmd/kubernetes-discoverer/main.go
+++ b/discovery/cmd/kubernetes-discoverer/main.go
@@ -37,7 +37,6 @@ var (
 	gimbalKubeCfgFile     string
 	discovererKubeCfgFile string
 	numProcessThreads     int
-	workingNamespace      string
 	clusterName           string
 	resyncInterval        time.Duration
 	debug                 bool


### PR DESCRIPTION
discovert/cmd/kubernetes-discoverer: remove constant workingNamespace
Signed-off-by: kpango <i.can.feel.gravity@gmail.com>