### PR TITLE
discovery/pkg/openstack/httplogger.go: fix error message punctuation

### DIFF
--- a/discovery/pkg/openstack/httplogger.go
+++ b/discovery/pkg/openstack/httplogger.go
@@ -57,7 +57,7 @@ func (lrt *LogRoundTripper) RoundTrip(request *http.Request) (*http.Response, er
 
 	if response.StatusCode == http.StatusUnauthorized {
 		if lrt.numReauthAttempts == 3 {
-			return response, fmt.Errorf("Tried to re-authenticate 3 times with no success")
+			return response, fmt.Errorf("tried to re-authenticate 3 times with no success")
 		}
 		lrt.numReauthAttempts++
 	}

--- a/discovery/pkg/openstack/httplogger.go
+++ b/discovery/pkg/openstack/httplogger.go
@@ -57,7 +57,7 @@ func (lrt *LogRoundTripper) RoundTrip(request *http.Request) (*http.Response, er
 
 	if response.StatusCode == http.StatusUnauthorized {
 		if lrt.numReauthAttempts == 3 {
-			return response, fmt.Errorf("Tried to re-authenticate 3 times with no success.")
+			return response, fmt.Errorf("Tried to re-authenticate 3 times with no success")
 		}
 		lrt.numReauthAttempts++
 	}


### PR DESCRIPTION
remove punctuation of error message end
see [this](https://github.com/golang/go/wiki/CodeReviewComments#error-strings) document
Signed-off-by: kpango <i.can.feel.gravity@gmail.com>