### PR TITLE
[WIP] Openstack: Improved handling of LB/Listener names

### DIFF
--- a/discovery/pkg/k8s/translate.go
+++ b/discovery/pkg/k8s/translate.go
@@ -23,7 +23,7 @@ func translateService(svc *v1.Service, clusterName string) *v1.Service {
 	newService := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: svc.Namespace,
-			Name:      translator.GetFormattedName(svc.Name, clusterName),
+			Name:      translator.BuildKubernetesDNSLabel(svc.Name, clusterName),
 			Labels:    translator.AddGimbalLabels(clusterName, svc.Namespace, svc.ObjectMeta.Name, svc.ObjectMeta.Labels),
 		},
 		Spec: v1.ServiceSpec{
@@ -45,7 +45,7 @@ func translateEndpoints(endpoints *v1.Endpoints, clusterName string) *v1.Endpoin
 	newEndpoint := &v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: endpoints.Namespace,
-			Name:      translator.GetFormattedName(endpoints.Name, clusterName),
+			Name:      translator.BuildKubernetesDNSLabel(endpoints.Name, clusterName),
 			Labels:    translator.AddGimbalLabels(clusterName, endpoints.Namespace, endpoints.ObjectMeta.Name, endpoints.ObjectMeta.Labels),
 		},
 		Subsets: endpoints.Subsets,

--- a/discovery/pkg/openstack/reconciler_test.go
+++ b/discovery/pkg/openstack/reconciler_test.go
@@ -1,0 +1,218 @@
+package openstack
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/listeners"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/loadbalancers"
+)
+
+func TestSkipInvalidLoadBalancers(t *testing.T) {
+	tests := []struct {
+		name     string
+		lbs      []loadbalancers.LoadBalancer
+		expected []loadbalancers.LoadBalancer
+	}{
+		{
+			name:     "empty slice",
+			lbs:      []loadbalancers.LoadBalancer{},
+			expected: []loadbalancers.LoadBalancer{},
+		},
+		{
+			name: "single valid lb, no listeners",
+			lbs: []loadbalancers.LoadBalancer{{
+				Name:      "foo123-Bar",
+				Listeners: []listeners.Listener{},
+			}},
+			expected: []loadbalancers.LoadBalancer{{
+				Name:      "foo123-Bar",
+				Listeners: []listeners.Listener{},
+			}},
+		},
+		{
+			name: "single valid lb, single valid listener",
+			lbs: []loadbalancers.LoadBalancer{{
+				Name:      "foo123-Bar",
+				Listeners: []listeners.Listener{{Name: "bar123-baz"}},
+			}},
+			expected: []loadbalancers.LoadBalancer{{
+				Name:      "foo123-Bar",
+				Listeners: []listeners.Listener{{Name: "bar123-baz"}},
+			}},
+		},
+		{
+			name: "single lb with invalid name (starts with number), no listener",
+			lbs: []loadbalancers.LoadBalancer{{
+				Name:      "123foo",
+				Listeners: []listeners.Listener{},
+			}},
+			expected: []loadbalancers.LoadBalancer{},
+		},
+		{
+			name: "single lb with invalid listener (name starts with number)",
+			lbs: []loadbalancers.LoadBalancer{{
+				Name:      "foo",
+				Listeners: []listeners.Listener{{Name: "123foo"}},
+			}},
+			expected: []loadbalancers.LoadBalancer{},
+		},
+		{
+			name: "single lb with valid and one invalid listener (name starts with number)",
+			lbs: []loadbalancers.LoadBalancer{{
+				Name:      "foo",
+				Listeners: []listeners.Listener{{Name: "foo"}, {Name: "123foo"}, {Name: "bar"}},
+			}},
+			expected: []loadbalancers.LoadBalancer{},
+		},
+		{
+			name: "multiple valid lbs, no listeners",
+			lbs: []loadbalancers.LoadBalancer{
+				{
+					Name:      "foo123-Bar",
+					Listeners: []listeners.Listener{},
+				},
+				{
+					Name:      "bar123-Baz",
+					Listeners: []listeners.Listener{},
+				},
+			},
+			expected: []loadbalancers.LoadBalancer{
+				{
+					Name:      "foo123-Bar",
+					Listeners: []listeners.Listener{},
+				},
+				{
+					Name:      "bar123-Baz",
+					Listeners: []listeners.Listener{},
+				},
+			},
+		},
+		{
+			name: "multiple valid lbs, valid listeners",
+			lbs: []loadbalancers.LoadBalancer{
+				{
+					Name:      "foo123-Bar",
+					Listeners: []listeners.Listener{{Name: "foo123-Barlis"}},
+				},
+				{
+					Name:      "bar123-Baz",
+					Listeners: []listeners.Listener{{Name: "bar123-Bazlis"}},
+				},
+			},
+			expected: []loadbalancers.LoadBalancer{
+				{
+					Name:      "foo123-Bar",
+					Listeners: []listeners.Listener{{Name: "foo123-Barlis"}},
+				},
+				{
+					Name:      "bar123-Baz",
+					Listeners: []listeners.Listener{{Name: "bar123-Bazlis"}},
+				},
+			},
+		},
+		{
+			name: "multiple lbs, one invalid",
+			lbs: []loadbalancers.LoadBalancer{
+				{
+					Name:      "foo123-Bar",
+					Listeners: []listeners.Listener{{Name: "foolis"}},
+				},
+				{
+					Name:      "123bar",
+					Listeners: []listeners.Listener{{Name: "barlis"}},
+				},
+				{
+					Name:      "bar123-Baz",
+					Listeners: []listeners.Listener{{Name: "barlis"}},
+				},
+			},
+			expected: []loadbalancers.LoadBalancer{
+				{
+					Name:      "foo123-Bar",
+					Listeners: []listeners.Listener{{Name: "foolis"}},
+				},
+				{
+					Name:      "bar123-Baz",
+					Listeners: []listeners.Listener{{Name: "barlis"}},
+				},
+			},
+		},
+		{
+			name: "multiple lbs, one invalid because of invalid listener",
+			lbs: []loadbalancers.LoadBalancer{
+				{
+					Name:      "foo",
+					Listeners: []listeners.Listener{{Name: "foolis"}},
+				},
+				{
+					Name:      "bar",
+					Listeners: []listeners.Listener{{Name: "123barlis"}},
+				},
+				{
+					Name:      "bar",
+					Listeners: []listeners.Listener{{Name: "barlis"}},
+				},
+			},
+			expected: []loadbalancers.LoadBalancer{
+				{
+					Name:      "foo",
+					Listeners: []listeners.Listener{{Name: "foolis"}},
+				},
+				{
+					Name:      "bar",
+					Listeners: []listeners.Listener{{Name: "barlis"}},
+				},
+			},
+		},
+		{
+			name: "multiple invalid lbs",
+			lbs: []loadbalancers.LoadBalancer{
+				{
+					Name:      "foo",
+					Listeners: []listeners.Listener{{Name: "foolis"}},
+				},
+				{
+					Name:      "0bar",
+					Listeners: []listeners.Listener{{Name: "barlis"}},
+				},
+				{
+					Name:      "foo_bar",
+					Listeners: []listeners.Listener{{Name: "barlis"}},
+				},
+				{
+					Name:      "foobar!",
+					Listeners: []listeners.Listener{{Name: "barlis"}},
+				},
+				{
+					Name:      "foo-bar!",
+					Listeners: []listeners.Listener{{Name: "barlis"}},
+				},
+				{
+					Name:      "-foo",
+					Listeners: []listeners.Listener{{Name: "barlis"}},
+				},
+				{
+					Name:      "foo-",
+					Listeners: []listeners.Listener{{Name: "barlis"}},
+				},
+			},
+			expected: []loadbalancers.LoadBalancer{
+				{
+					Name:      "foo",
+					Listeners: []listeners.Listener{{Name: "foolis"}},
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		r := Reconciler{
+			Logger: logrus.New(),
+		}
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, r.skipInvalidLoadBalancers("projectname", tc.lbs))
+		})
+	}
+}

--- a/discovery/pkg/openstack/translate.go
+++ b/discovery/pkg/openstack/translate.go
@@ -34,7 +34,7 @@ func kubeServices(clusterName, tenantName string, lbs []loadbalancers.LoadBalanc
 		svc := v1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: tenantName,
-				Name:      translator.GetFormattedName(serviceName(lb), clusterName),
+				Name:      translator.BuildKubernetesDNSLabel(serviceName(lb), clusterName),
 				Labels:    translator.AddGimbalLabels(clusterName, tenantName, serviceName(lb), loadbalancerLabels(lb)),
 			},
 			Spec: v1.ServiceSpec{
@@ -57,7 +57,7 @@ func kubeEndpoints(clusterName, tenantName string, lbs []loadbalancers.LoadBalan
 		ep := v1.Endpoints{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: tenantName,
-				Name:      translator.GetFormattedName(serviceName(lb), clusterName),
+				Name:      translator.BuildKubernetesDNSLabel(serviceName(lb), clusterName),
 				Labels:    translator.AddGimbalLabels(clusterName, tenantName, serviceName(lb), loadbalancerLabels(lb)),
 			},
 		}
@@ -104,13 +104,15 @@ func loadbalancerLabels(lb loadbalancers.LoadBalancer) map[string]string {
 	}
 }
 
+// By default, the load balancer's ID is used as the service name, given that
+// names in OpenStack are optional and are not guaranteed to be unique. In the
+// case that the load balancer has a non-empty name, the ID is appended to
+// produce a unique service name.
 func serviceName(lb loadbalancers.LoadBalancer) string {
-	// OpenStack names are optional
-	lbName := lb.ID
-	if lb.Name != "" {
-		lbName = fmt.Sprintf("%s-%s", lb.Name, lb.ID)
+	if lb.Name == "" {
+		return lb.ID
 	}
-	return lbName
+	return fmt.Sprintf("%s-%s", lb.Name, lb.ID)
 }
 
 func servicePort(listener *listeners.Listener) v1.ServicePort {
@@ -127,5 +129,6 @@ func portName(listener *listeners.Listener) string {
 	if listener.Name == "" {
 		return "unnamed-" + p // TODO: port names must have at least 1 char. Is there something better we can do here?
 	}
-	return listener.Name + "-" + p
+	// port names must be kubernetes DNS_LABELs
+	return translator.BuildKubernetesDNSLabel(listener.Name, p)
 }

--- a/discovery/pkg/openstack/translate_test.go
+++ b/discovery/pkg/openstack/translate_test.go
@@ -34,6 +34,74 @@ func TestKubeServices(t *testing.T) {
 		expected    []v1.Service
 	}{
 		{
+			name:        "unnamed lb, no listener",
+			clusterName: "us-east",
+			tenantName:  "finance",
+			lbs: []loadbalancers.LoadBalancer{
+				loadbalancer("5a5c3d9e-e679-43ec-b9fc-9bc51132541e", ""),
+			},
+			expected: []v1.Service{
+				service("finance", "5a5c3d9e-e679-43ec-b9fc-9bc51132541e-us-east",
+					map[string]string{
+						"gimbal.heptio.com/cluster":            "us-east",
+						"gimbal.heptio.com/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.heptio.com/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.heptio.com/load-balancer-name": ""},
+					nil),
+			},
+		},
+		{
+			name:        "named lb, no listener",
+			clusterName: "us-east",
+			tenantName:  "finance",
+			lbs: []loadbalancers.LoadBalancer{
+				loadbalancer("5a5c3d9e-e679-43ec-b9fc-9bc51132541e", "stocks"),
+			},
+			expected: []v1.Service{
+				service("finance", "stocks-5a5c3d9e-e679-43ec-b9fc-9bc51132541e-us-east",
+					map[string]string{
+						"gimbal.heptio.com/cluster":            "us-east",
+						"gimbal.heptio.com/service":            "stocks-5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.heptio.com/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.heptio.com/load-balancer-name": "stocks"},
+					nil),
+			},
+		},
+		{
+			name:        "lb name has uppercase letters, no listener",
+			clusterName: "us-east",
+			tenantName:  "finance",
+			lbs: []loadbalancers.LoadBalancer{
+				loadbalancer("5a5c3d9e-e679-43ec-b9fc-9bc51132541e", "STOCKS"),
+			},
+			expected: []v1.Service{
+				service("finance", "stocks-5a5c3d9e-e679-43ec-b9fc-9bc51132541e-us-east",
+					map[string]string{
+						"gimbal.heptio.com/cluster":            "us-east",
+						"gimbal.heptio.com/service":            "STOCKS-5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.heptio.com/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.heptio.com/load-balancer-name": "STOCKS"},
+					nil),
+			},
+		},
+		{
+			name:        "long lb name, no listener",
+			clusterName: "us-east",
+			tenantName:  "finance",
+			lbs: []loadbalancers.LoadBalancer{
+				loadbalancer("5a5c3d9e-e679-43ec-b9fc-9bc51132541e", "H8O5dRuRZlLfzjOC4a6spBTnsNUmGGlVNCerKkeeK4w5qjgaDVa9ogLKBPJX539p"),
+			},
+			expected: []v1.Service{
+				service("finance", "h8o5drurzllfzjoc4a6spbtn-9f88a4-us-east",
+					map[string]string{
+						"gimbal.heptio.com/cluster":            "us-east",
+						"gimbal.heptio.com/service":            "H8O5dRuRZlLfzjOC4a6spBTnsNUmGGlVNCerKkeeK4w5qjgaDVa9ogLKBPJX539p-5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.heptio.com/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.heptio.com/load-balancer-name": "H8O5dRuRZlLfzjOC4a6spBTnsNUmGGlVNCerKkeeK4w5qjgaDVa9ogLKBPJX539p"},
+					nil),
+			},
+		},
+		{
 			name:        "named lb, one listener",
 			clusterName: "us-east",
 			tenantName:  "finance",
@@ -50,6 +118,52 @@ func TestKubeServices(t *testing.T) {
 					[]v1.ServicePort{
 						{
 							Name:     "http-80",
+							Port:     80,
+							Protocol: v1.ProtocolTCP,
+						},
+					}),
+			},
+		},
+		{
+			name:        "named lb, one listener with uppercase name",
+			clusterName: "us-east",
+			tenantName:  "finance",
+			lbs: []loadbalancers.LoadBalancer{
+				loadbalancer("5a5c3d9e-e679-43ec-b9fc-9bc51132541e", "stocks", listener("ls-1", "HTTP", "tcp", "pool-1", 80)),
+			},
+			expected: []v1.Service{
+				service("finance", "stocks-5a5c3d9e-e679-43ec-b9fc-9bc51132541e-us-east",
+					map[string]string{
+						"gimbal.heptio.com/cluster":            "us-east",
+						"gimbal.heptio.com/service":            "stocks-5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.heptio.com/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.heptio.com/load-balancer-name": "stocks"},
+					[]v1.ServicePort{
+						{
+							Name:     "http-80",
+							Port:     80,
+							Protocol: v1.ProtocolTCP,
+						},
+					}),
+			},
+		},
+		{
+			name:        "named lb, one listener with long name",
+			clusterName: "us-east",
+			tenantName:  "finance",
+			lbs: []loadbalancers.LoadBalancer{
+				loadbalancer("5a5c3d9e-e679-43ec-b9fc-9bc51132541e", "stocks", listener("ls-1", "H8O5dRuRZlLfzjOC4a6spBTnsNUmGGlVNCerKkeeK4w5qjgaDVa9ogLKBPJX539p", "tcp", "pool-1", 80)),
+			},
+			expected: []v1.Service{
+				service("finance", "stocks-5a5c3d9e-e679-43ec-b9fc-9bc51132541e-us-east",
+					map[string]string{
+						"gimbal.heptio.com/cluster":            "us-east",
+						"gimbal.heptio.com/service":            "stocks-5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.heptio.com/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.heptio.com/load-balancer-name": "stocks"},
+					[]v1.ServicePort{
+						{
+							Name:     "h8o5drurzllfzjoc4a6spbtn-9c4814-80",
 							Port:     80,
 							Protocol: v1.ProtocolTCP,
 						},
@@ -133,11 +247,121 @@ func TestKubeEndpoints(t *testing.T) {
 		expected    []v1.Endpoints
 	}{
 		{
+			name:        "named load balancer, no listener",
+			clusterName: "us-east",
+			tenantName:  "finance",
+			lbs: []loadbalancers.LoadBalancer{
+				loadbalancer("5a5c3d9e-e679-43ec-b9fc-9bc51132541e", "stocks"),
+			},
+			pools: []pools.Pool{
+				pool("pool-1", "HTTP", "5a5c3d9e-e679-43ec-b9fc-9bc51132541e", poolmember("10.0.0.1", 8080)),
+			},
+			expected: []v1.Endpoints{
+				endpoints("finance", "stocks-5a5c3d9e-e679-43ec-b9fc-9bc51132541e-us-east",
+					map[string]string{
+						"gimbal.heptio.com/cluster":            "us-east",
+						"gimbal.heptio.com/service":            "stocks-5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.heptio.com/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.heptio.com/load-balancer-name": "stocks"},
+					nil),
+			},
+		},
+		{
+			name:        "long load balancer name, no listener",
+			clusterName: "us-east",
+			tenantName:  "finance",
+			lbs: []loadbalancers.LoadBalancer{
+				loadbalancer("5a5c3d9e-e679-43ec-b9fc-9bc51132541e", "H8O5dRuRZlLfzjOC4a6spBTnsNUmGGlVNCerKkeeK4w5qjgaDVa9ogLKBPJX539p"),
+			},
+			pools: []pools.Pool{
+				pool("pool-1", "HTTP", "5a5c3d9e-e679-43ec-b9fc-9bc51132541e", poolmember("10.0.0.1", 8080)),
+			},
+			expected: []v1.Endpoints{
+				endpoints("finance", "h8o5drurzllfzjoc4a6spbtn-9f88a4-us-east",
+					map[string]string{
+						"gimbal.heptio.com/cluster":            "us-east",
+						"gimbal.heptio.com/service":            "H8O5dRuRZlLfzjOC4a6spBTnsNUmGGlVNCerKkeeK4w5qjgaDVa9ogLKBPJX539p-5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.heptio.com/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.heptio.com/load-balancer-name": "H8O5dRuRZlLfzjOC4a6spBTnsNUmGGlVNCerKkeeK4w5qjgaDVa9ogLKBPJX539p"},
+					nil),
+			},
+		},
+		{
+			name:        "uppercase load balancer name, no listener",
+			clusterName: "us-east",
+			tenantName:  "finance",
+			lbs: []loadbalancers.LoadBalancer{
+				loadbalancer("5a5c3d9e-e679-43ec-b9fc-9bc51132541e", "STOCKS"),
+			},
+			pools: []pools.Pool{
+				pool("pool-1", "HTTP", "5a5c3d9e-e679-43ec-b9fc-9bc51132541e", poolmember("10.0.0.1", 8080)),
+			},
+			expected: []v1.Endpoints{
+				endpoints("finance", "stocks-5a5c3d9e-e679-43ec-b9fc-9bc51132541e-us-east",
+					map[string]string{
+						"gimbal.heptio.com/cluster":            "us-east",
+						"gimbal.heptio.com/service":            "STOCKS-5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.heptio.com/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.heptio.com/load-balancer-name": "STOCKS"},
+					nil),
+			},
+		},
+		{
 			name:        "single listener",
 			clusterName: "us-east",
 			tenantName:  "finance",
 			lbs: []loadbalancers.LoadBalancer{
 				loadbalancer("5a5c3d9e-e679-43ec-b9fc-9bc51132541e", "stocks", listener("970fd223-4684-4c50-bfa2-738d6dda096f", "http", "tcp", "pool-1", 80)),
+			},
+			pools: []pools.Pool{
+				pool("pool-1", "HTTP", "5a5c3d9e-e679-43ec-b9fc-9bc51132541e", poolmember("10.0.0.1", 8080)),
+			},
+			expected: []v1.Endpoints{
+				endpoints("finance", "stocks-5a5c3d9e-e679-43ec-b9fc-9bc51132541e-us-east",
+					map[string]string{
+						"gimbal.heptio.com/cluster":            "us-east",
+						"gimbal.heptio.com/service":            "stocks-5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.heptio.com/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.heptio.com/load-balancer-name": "stocks"},
+					[]v1.EndpointSubset{
+						{
+							Addresses: []v1.EndpointAddress{{IP: "10.0.0.1"}},
+							Ports:     []v1.EndpointPort{{Name: "http-80", Port: 8080, Protocol: v1.ProtocolTCP}},
+						},
+					}),
+			},
+		},
+		{
+			name:        "single listener with long name",
+			clusterName: "us-east",
+			tenantName:  "finance",
+			lbs: []loadbalancers.LoadBalancer{
+				loadbalancer("5a5c3d9e-e679-43ec-b9fc-9bc51132541e", "stocks", listener("970fd223-4684-4c50-bfa2-738d6dda096f", "H8O5dRuRZlLfzjOC4a6spBTnsNUmGGlVNCerKkeeK4w5qjgaDVa9ogLKBPJX539p", "tcp", "pool-1", 80)),
+			},
+			pools: []pools.Pool{
+				pool("pool-1", "HTTP", "5a5c3d9e-e679-43ec-b9fc-9bc51132541e", poolmember("10.0.0.1", 8080)),
+			},
+			expected: []v1.Endpoints{
+				endpoints("finance", "stocks-5a5c3d9e-e679-43ec-b9fc-9bc51132541e-us-east",
+					map[string]string{
+						"gimbal.heptio.com/cluster":            "us-east",
+						"gimbal.heptio.com/service":            "stocks-5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.heptio.com/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.heptio.com/load-balancer-name": "stocks"},
+					[]v1.EndpointSubset{
+						{
+							Addresses: []v1.EndpointAddress{{IP: "10.0.0.1"}},
+							Ports:     []v1.EndpointPort{{Name: "h8o5drurzllfzjoc4a6spbtn-9c4814-80", Port: 8080, Protocol: v1.ProtocolTCP}},
+						},
+					}),
+			},
+		},
+		{
+			name:        "single listener with uppercase name",
+			clusterName: "us-east",
+			tenantName:  "finance",
+			lbs: []loadbalancers.LoadBalancer{
+				loadbalancer("5a5c3d9e-e679-43ec-b9fc-9bc51132541e", "stocks", listener("970fd223-4684-4c50-bfa2-738d6dda096f", "HTTP", "tcp", "pool-1", 80)),
 			},
 			pools: []pools.Pool{
 				pool("pool-1", "HTTP", "5a5c3d9e-e679-43ec-b9fc-9bc51132541e", poolmember("10.0.0.1", 8080)),

--- a/discovery/pkg/translator/translator.go
+++ b/discovery/pkg/translator/translator.go
@@ -23,8 +23,8 @@ const (
 	// GimbalLabelCluster is the key of the label that contains the cluster name
 	GimbalLabelCluster = "gimbal.heptio.com/cluster"
 	gimbalLabelService = "gimbal.heptio.com/service"
-	// Services in Kubernetes are limited to 63 characters in length
-	maxNameLength = 63
+	// https://github.com/kubernetes/community/blob/master/contributors/design-proposals/architecture/identifiers.md
+	kubernetesDNSLabelMaxLength = 63
 )
 
 // AddGimbalLabels returns a new set of labels that includes the incoming set of
@@ -44,16 +44,36 @@ func AddGimbalLabels(clustername, namespace, name string, existingLabels map[str
 	return existingLabels
 }
 
-// GetFormattedName take the names of a service and formats to truncate if needed
-func GetFormattedName(name, cluster string) string {
-	return hashname(maxNameLength, name, cluster)
+// BuildKubernetesDNSLabel joins and lowercases the incoming strings into a
+// single string using "-" as a separator, making sure the resulting string
+// conforms to the Kubernetes DNS Label specification:
+//
+// "An alphanumeric (a-z, and 0-9) string, with a maximum length of 63
+// characters, with the '-' character allowed anywhere except the first or last
+// character, suitable for use as a hostname or segment in a domain name."
+// (https://github.com/kubernetes/community/blob/master/contributors/design-proposals/architecture/identifiers.md)
+//
+// If the combined length exceeds 63 characters, each string in s will be
+// shortened if its length is greater than 63/len(s) using a hash derived from
+// the contents of s (not the current element). In other words, each string in s
+// gets alloted an equal maximum size that it can fill, and is shortened in the
+// case that it goes over the maximum length.
+//
+// The shortening process starts from the last element in s, and will continue
+// shortening each element of s until the resulting string does not exceed 63
+// characters. If all elements are shortened, and the final string is still
+// greater than 63 characters, the entire string is replaced with the hash of
+// the contents of s.
+func BuildKubernetesDNSLabel(s ...string) string {
+	joined := hashname(kubernetesDNSLabelMaxLength, s...)
+	return strings.ToLower(joined)
 }
 
 // hashname takes a lenth l and a varargs of strings s and returns a string whose length
-// which does not exceed l. Internally s is joined with strings.Join(s, "/"). If the
-// combined length exceeds l then hashname truncates each element in s, starting from the
+// which does not exceed l. Internally s is joined with strings.Join(s, "-"). If the
+// combined length exceeds l then hashname shortens each element in s, starting from the
 // end using a hash derived from the contents of s (not the current element). This process
-// continues until the length of s does not exceed l, or all elements have been truncated.
+// continues until the length of s does not exceed l, or all elements have been shortened.
 // In which case, the entire string is replaced with a hash not exceeding the length of l.
 func hashname(l int, s ...string) string {
 	const shorthash = 6 // the length of the shorthash
@@ -65,7 +85,7 @@ func hashname(l int, s ...string) string {
 	}
 	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(r)))
 	for n := len(s) - 1; n >= 0; n-- {
-		s[n] = truncate(l/len(s), s[n], hash[:shorthash])
+		s[n] = shorten(l/len(s), s[n], hash[:shorthash])
 		r = strings.Join(s, "-")
 		if l > len(r) {
 			return r
@@ -76,9 +96,9 @@ func hashname(l int, s ...string) string {
 	return hash[:min(len(hash), l)]
 }
 
-// truncate truncates s to l length by replacing the
+// shorten shortens s to l length by replacing the
 // end of s with -suffix.
-func truncate(l int, s, suffix string) string {
+func shorten(l int, s, suffix string) string {
 	if l >= len(s) {
 		// under the limit, nothing to do
 		return s

--- a/discovery/pkg/translator/translator_test.go
+++ b/discovery/pkg/translator/translator_test.go
@@ -19,41 +19,59 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetFormattedName(t *testing.T) {
+func TestBuildKubernetesDNSLabel(t *testing.T) {
 	tests := []struct {
-		name        string
-		serviceName string
-		cluster     string
-		expected    string
+		name       string
+		components []string
+		expected   string
 	}{
 		{
-			name:        "basic",
-			serviceName: "service1",
-			cluster:     "cluster1",
-			expected:    "service1-cluster1",
+			name:       "basic",
+			components: []string{"service1", "cluster1"},
+			expected:   "service1-cluster1",
 		},
 		{
-			name:        "long service name",
-			serviceName: "service1service1service1service1service1service1service1service1service1service1service1service1service1",
-			cluster:     "cluster1",
-			expected:    "service1service1service1-d8cb7f-cluster1",
+			name: "one long name",
+			components: []string{
+				"service1service1service1service1service1service1service1service1service1service1service1service1service1",
+				"cluster1",
+			},
+			expected: "service1service1service1-d8cb7f-cluster1",
 		},
 		{
-			name:        "long cluster name",
-			serviceName: "service1service1service1service1service1service1service1service1service1service1service1service1service1",
-			cluster:     "cluster1cluster1cluster1cluster1cluster1cluster1cluster1cluster1",
-			expected:    "4ce97d89bfa193a277ddd97df3cad58484b30bb4bc4b815ea71c84518d9a830",
+			name: "both long names",
+			components: []string{
+				"service1service1service1service1service1service1service1service1service1service1service1service1service1",
+				"cluster1cluster1cluster1cluster1cluster1cluster1cluster1cluster1",
+			},
+			expected: "4ce97d89bfa193a277ddd97df3cad58484b30bb4bc4b815ea71c84518d9a830",
+		},
+		{
+			name:       "uppercase characters in one of the components",
+			components: []string{"FOO", "bar"},
+			expected:   "foo-bar",
+		},
+		{
+			name:       "one uppercase component",
+			components: []string{"FOO"},
+			expected:   "foo",
+		},
+		{
+			name:       "one long component",
+			components: []string{"service1service1service1service1service1service1service1service1service1service1service1service1service1"},
+			expected:   "bbaff9d26694ea6a881ebd3daf025e0daf0921f7398789053aeef0ac39be935",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result := GetFormattedName(test.serviceName, test.cluster)
+			result := BuildKubernetesDNSLabel(test.components...)
 
 			assert.Equal(t, test.expected, result, "Expected name does not match")
 		})
 	}
 }
+
 func TestAddLabels(t *testing.T) {
 	clusterName := "test01"
 	namespace := "default"


### PR DESCRIPTION
Fixes #71 

With this PR, the OpenStack discoverer will now make sure that EndpointPort names are valid according to the Kubernetes specification. Additionally, the OpenStack discoverer will skip discovery  of load balancers that have a) invalid names or b) listeners that have invalid names, and log a message instead.

A valid name is one that adheres to the Kubernetes [DNS_LABEL specification](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/architecture/identifiers.md), although we relax some of the requirements:
- The name can contain uppercase letters. This is to avoid asking users to rename a large number of existing load balancers. The discoverer will lowercase the names before creating services/endpoints.
- The name is not limited to 63 characters. The discoverer will shorten the name when needed.

To do:
- [ ] document openstack naming requirements
- [ ] validate/handle labels