### PR TITLE
Remove needless nil check

### DIFF
--- a/discovery/pkg/translator/translator.go
+++ b/discovery/pkg/translator/translator.go
@@ -34,14 +34,11 @@ func AddGimbalLabels(clustername, namespace, name string, existingLabels map[str
 		GimbalLabelCluster: clustername,
 		gimbalLabelService: name,
 	}
-	if existingLabels == nil {
-		return gimbalLabels
-	}
 	// Set gimbal labels on the existing labels map
-	for k, v := range gimbalLabels {
-		existingLabels[k] = v
+	for k, v := range existingLabels {
+		gimbalLabels[k] = v
 	}
-	return existingLabels
+	return gimbalLabels
 }
 
 // GetFormattedName take the names of a service and formats to truncate if needed


### PR DESCRIPTION
Remove needless nil check.
If ```existingLabels ``` is nil, it will never enter the for loop, so the above nil check is needless
Signed-off-by: kpango <i.can.feel.gravity@gmail.com>