### PR TITLE
Enable statsd metrics collection for histograms

### DIFF
--- a/deployment/contour/02-statsd.yaml
+++ b/deployment/contour/02-statsd.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: envoy-statsd
+  namespace: gimbal-contour
+data:
+  statsd.yaml: |2-
+    mappings: 
+    - match: 'envoy.cluster.*.upstream_cx_connect_ms'
+      name: "envoy_cluster_upstream_cx_connect_time"
+      timer_type: 'histogram'
+      labels:
+        cluster_name: "$1"
+    - match: 'envoy.cluster.*.upstream_cx_length_ms'
+      name: "envoy_cluster_upstream_cx_length"
+      timer_type: 'histogram'
+      labels:
+        cluster_name: "$1"
+    - match: 'envoy.cluster.*.upstream_rq_time'
+      name: "envoy_cluster_upstream_rq_time"
+      timer_type: 'histogram'
+      labels:
+        cluster_name: "$1"
+    - match: 'envoy.cluster.*.internal.upstream_rq_time'
+      name: "envoy_cluster_internal_upstream_rq_time"
+      timer_type: 'histogram'
+      labels:
+        cluster_name: "$1"
+    - match: 'envoy.cluster.*.external.upstream_rq_time'
+      name: "envoy_cluster_external_upstream_rq_time"
+      timer_type: 'histogram'
+      labels:
+        cluster_name: "$1"
+    - match: 'envoy.cluster.*.canary.upstream_rq_time'
+      name: "envoy_cluster_canary_upstream_rq_time"
+      timer_type: 'histogram'
+      labels:
+        cluster_name: "$1"
+    - match: 'envoy.http.*.downstream_cx_length_ms'
+      name: "envoy_http_downstream_cx_length"
+      timer_type: 'histogram'
+      labels:
+        http_conn_manager_prefix: "$1"
+    - match: 'envoy.http.*.downstream_rq_time'
+      name: "envoy_http_downstream_rq_time"
+      timer_type: 'histogram'
+      labels:
+        http_conn_manager_prefix: "$1"
+    - match: '.'
+      match_type: 'regex'
+      action: 'drop'
+      name: 'dropped'

--- a/deployment/contour/03-contour.yaml
+++ b/deployment/contour/03-contour.yaml
@@ -35,7 +35,7 @@ spec:
         - --envoy-http-port
         - "80"
         command: ["contour"]
-        image: gcr.io/heptio-images/contour:v0.5.0
+        image: gcr.io/heptio-images/contour:master
         imagePullPolicy: Always
         name: contour
         ports:

--- a/deployment/contour/03-envoy.yaml
+++ b/deployment/contour/03-envoy.yaml
@@ -12,10 +12,11 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/format: prometheus
-        prometheus.io/path: /stats
-        prometheus.io/port: "9001"
         prometheus.io/scrape: "true"
+        prometheus.io/port: "9001"
+        prometheus.io/statsdport: "9102"
+        prometheus.io/path: "/stats"
+        prometheus.io/format: "prometheus"
       labels:
         app: envoy
     spec:
@@ -44,6 +45,19 @@ spec:
         volumeMounts:
           - name: contour-config
             mountPath: /config
+      - name: statsd-sink
+        image: prom/statsd-exporter:v0.6.0
+        command: 
+            - "/bin/statsd_exporter"
+        args:
+            - "-statsd.mapping-config=/etc/statsd/statsd.yaml"
+        ports:
+        - containerPort: 9102
+          protocol: TCP
+          name: metrics
+        volumeMounts:
+            - name: statsd
+              mountPath: /etc/statsd
       dnsPolicy: ClusterFirst
       hostNetwork: true
       initContainers:
@@ -56,6 +70,7 @@ spec:
         - $(CONTOUR_SERVICE_HOST)
         - --xds-port
         - $(CONTOUR_SERVICE_PORT)
+        - --statsd-enabled
         command:
         - contour
         image: gcr.io/heptio-images/contour:v0.5.0
@@ -66,6 +81,9 @@ spec:
           mountPath: /config
       automountServiceAccountToken: false   
       volumes:
-      - name: contour-config
-        emptyDir: {}
+        - name: contour-config
+          emptyDir: {}
+        - name: statsd
+          configMap:
+            name: envoy-statsd
       restartPolicy: Always

--- a/deployment/contour/03-envoy.yaml
+++ b/deployment/contour/03-envoy.yaml
@@ -73,8 +73,8 @@ spec:
         - --statsd-enabled
         command:
         - contour
-        image: gcr.io/heptio-images/contour:v0.5.0
-        imagePullPolicy: IfNotPresent
+        image: gcr.io/heptio-images/contour:master
+        imagePullPolicy: Always
         name: envoy-initconfig
         volumeMounts:
         - name: contour-config

--- a/deployment/prometheus/02-prometheus-configmap.yaml
+++ b/deployment/prometheus/02-prometheus-configmap.yaml
@@ -297,6 +297,30 @@ data:
         action: replace
         target_label: kubernetes_pod_name
 
+    - job_name: 'envoy-statsd'
+      scrape_interval: 30s
+
+      kubernetes_sd_configs:
+      - role: pod
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+        action: keep
+        regex: true
+      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_statsdport]
+        action: replace
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        target_label: __address__
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: kubernetes_namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: kubernetes_pod_name
+
     alerting:
       alertmanagers:
       # Discover alert manager instances using K8s service discovery

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -60,7 +60,7 @@ Envoy emits three types of values as statistics:
 
 - **Counters:** Unsigned integers that only increase and never decrease. E.g., total requests.
 - **Gauges:** Unsigned integers that both increase and decrease. E.g., currently active requests.
-- **Histograms:** Unsigned integers that are part of a stream of values that are then aggregated by the collector to ultimately yield summarized percentile values. E.g., upstream request time. _NOTE: Histograms are not currently supported in Prometheus directly._
+- **Histograms:** Unsigned integers that are part of a stream of values that are then aggregated by the collector to ultimately yield summarized percentile values. E.g., upstream request time.
 
 Detailed documentation on stats within Envoy are available on their site: https://www.envoyproxy.io/docs/envoy/latest/configuration/cluster_manager/cluster_stats#config-cluster-manager-cluster-stats
 


### PR DESCRIPTION
This enables histogram support for Envoy metrics by using the [statsd exporter](https://github.com/prometheus/statsd_exporter) to collect data from Envoy and then allow Prometheus to scrape for those metrics. 

Note this PR has non-standard Contour builds as it depends on changes to enable statsd endpoints. PR for that is heptio/contour#366. Once that merges we can update the image to use a `master` tag until a new release of Contour. 

Fixes #92 

Signed-off-by: Steve Sloka <steves@heptio.com>