### PR TITLE
Stop exposing Envoy admin interface

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -50,7 +50,7 @@ $ kubectl create -f contour/
 
 The deployment also includes sample Network Policies which restrict access to Contour and Envoy as well as allow access from Prometheus to scrape for metrics. 
 
-**NOTE**: The current configuration exposes the Envoy Admin UI so that Prometheus can scrape for metrics.
+**NOTE**: The current configuration exposes the `/stats` path from the Envoy Admin UI so that Prometheus can scrape for metrics.
 
 ## Deploy Discoverers
 

--- a/deployment/contour/03-envoy.yaml
+++ b/deployment/contour/03-envoy.yaml
@@ -13,7 +13,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/port: "9001"
+        prometheus.io/port: "8001"
         prometheus.io/statsdport: "9102"
         prometheus.io/path: "/stats"
         prometheus.io/format: "prometheus"
@@ -64,8 +64,6 @@ spec:
       - args:
         - bootstrap
         - /config/contour.yaml
-        - --admin-address
-        - 0.0.0.0
         - --xds-address
         - $(CONTOUR_SERVICE_HOST)
         - --xds-port


### PR DESCRIPTION
This fixes #90 & #80 by implementing upstream changes from Contour which will now only expose `/stats` on a port and not the entire admin interface. 

Signed-off-by: Steve Sloka <steves@heptio.com>