### PR TITLE
[Doc] Specify the Secret key for the kubeconfig data

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -70,7 +70,7 @@ The Kubernetes Discoverer is responsible for looking at all services and endpoin
 ```sh
 # Kubernetes secret
 $ kubectl -n gimbal-discovery create secret generic remote-discover-kubecfg \
-    --from-file=./config \
+    --from-file=config=./config \
     --from-literal=cluster-name=node02
 
 # Deploy Discoverer


### PR DESCRIPTION
If a user follows our docs and tries to create a k8s discoverer secret with a different filename than `config`, the deployment will fail.

This PR explicitly specifies the Secret key to be `config`, regardless of which filename the kubeconfig data is in.

Signed-off-by: Ross Kukulinski <ross@kukulinski.com>