### PR TITLE
grafana: update prometheus query to use new gimbal label

### DIFF
--- a/deployment/grafana/02-grafana-configmap.yaml
+++ b/deployment/grafana/02-grafana-configmap.yaml
@@ -95,7 +95,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "count(kube_service_labels{namespace=~\"$Namespace\",label_gimbal_heptio_com_cluster=~\"$BackendCluster\"}) ",
+              "expr": "count(kube_service_labels{namespace=~\"$Namespace\",label_gimbal_heptio_com_backend=~\"$BackendCluster\"}) ",
               "format": "time_series",
               "intervalFactor": 1,
               "refId": "B"
@@ -174,7 +174,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "count(kube_endpoint_labels{namespace=~\"$Namespace\",label_gimbal_heptio_com_cluster=~\"$BackendCluster\"}) ",
+              "expr": "count(kube_endpoint_labels{namespace=~\"$Namespace\",label_gimbal_heptio_com_backend=~\"$BackendCluster\"}) ",
               "format": "time_series",
               "intervalFactor": 1,
               "refId": "A"


### PR DESCRIPTION
Fixes #115 

Update the prometheus query we are using in the discovery dashboards to count the number of discovered services to use `gimbal.heptio.com/backend` instead of `gimbal.heptio.com/cluster`.