### PR TITLE
deployment: update discoverer images to latest released version

### DIFF
--- a/deployment/gimbal-discoverer/02-kubernetes-discoverer.yaml
+++ b/deployment/gimbal-discoverer/02-kubernetes-discoverer.yaml
@@ -22,7 +22,7 @@ spec:
         prometheus.io/port: "8080"
     spec:
       containers:
-      - image: gcr.io/heptio-images/gimbal-discoverer:master
+      - image: gcr.io/heptio-images/gimbal-discoverer:v0.2.0
         imagePullPolicy: Always
         name: kubernetes-discoverer
         command: ["/kubernetes-discoverer"]

--- a/deployment/gimbal-discoverer/02-openstack-discoverer.yaml
+++ b/deployment/gimbal-discoverer/02-openstack-discoverer.yaml
@@ -22,7 +22,7 @@ spec:
         cluster: openstack
     spec:
       containers:
-        - image: gcr.io/heptio-images/gimbal-discoverer:master
+        - image: gcr.io/heptio-images/gimbal-discoverer:v0.2.0
           imagePullPolicy: Always
           name: openstack-discoverer
           command: ["/openstack-discoverer"]


### PR DESCRIPTION
Update discoverer deployment files to use `v0.2.0` tag instead of `master`.