### PR TITLE
prometheus: envoy-statsd job ignore pods that don't have the statsd port annotation

### DIFF
--- a/deployment/prometheus/02-prometheus-configmap.yaml
+++ b/deployment/prometheus/02-prometheus-configmap.yaml
@@ -323,6 +323,10 @@ data:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true
+      # Only scrape pods that have the statsdport annotation set to a number
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_statsdport]
+        action: keep
+        regex: ^\d+$
       - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_statsdport]
         action: replace
         regex: ([^:]+)(?::\d+)?;(\d+)


### PR DESCRIPTION
The envoy-statsd scrape job should only scrape the envoy-statsd pods. Thus, only keep the pods that have the statsdport annotation.

Fixes #132 

