### PR TITLE
discovery: fix syncqueue retries

### DIFF
--- a/discovery/pkg/sync/queue.go
+++ b/discovery/pkg/sync/queue.go
@@ -29,7 +29,7 @@ const (
 	actionAdd       = "add"
 	actionUpdate    = "update"
 	actionDelete    = "delete"
-	queueMaxRetries = 5
+	queueMaxRetries = 3
 )
 
 // Queue syncs resources with the Gimbal cluster by working through a queue of

--- a/discovery/pkg/sync/queue.go
+++ b/discovery/pkg/sync/queue.go
@@ -14,7 +14,6 @@
 package sync
 
 import (
-	"fmt"
 	"time"
 
 	localmetrics "github.com/heptio/gimbal/discovery/pkg/metrics"
@@ -27,9 +26,10 @@ import (
 )
 
 const (
-	actionAdd    = "add"
-	actionUpdate = "update"
-	actionDelete = "delete"
+	actionAdd       = "add"
+	actionUpdate    = "update"
+	actionDelete    = "delete"
+	queueMaxRetries = 5
 )
 
 // Queue syncs resources with the Gimbal cluster by working through a queue of
@@ -103,38 +103,41 @@ func (sq *Queue) processNextWorkItem() bool {
 		return false
 	}
 
-	// We wrap this block in a func so we can defer sq.workqueue.Done.
-	err := func(obj interface{}) error {
-		// We call Done here so the workqueue knows we have finished processing
-		// this item. We also must remember to call Forget if we do not want
-		// this work item being re-queued. For example, we do not call Forget if
-		// a transient error occurs, instead the item is put back on the
-		// workqueue and attempted again after a back-off period.
-		defer sq.Workqueue.Done(obj)
+	// Tell the queue that we are done with processing this key. This unblocks
+	// the key for other workers.
+	defer sq.Workqueue.Done(obj)
 
-		action, ok := obj.(Action)
-		if !ok {
-			sq.Workqueue.Forget(obj)
-			sq.Metrics.QueueSizeGaugeMetric(sq.BackendName, sq.ClusterType, sq.Workqueue.Len())
-			return fmt.Errorf("ignoring unknown item of type %T in queue", obj)
-		}
-
-		err := action.Sync(sq.KubeClient, sq.Metrics, sq.BackendName)
-		if err != nil {
-			return err
-		}
-		sq.Logger.Infof("Successfully handled: %s", action)
-
-		// Finally, if no error occurs we Forget this item so it does not
-		// get queued again until another change happens.
+	action, ok := obj.(Action)
+	if !ok {
 		sq.Workqueue.Forget(obj)
 		sq.Metrics.QueueSizeGaugeMetric(sq.BackendName, sq.ClusterType, sq.Workqueue.Len())
-		return nil
-	}(obj)
-
-	if err != nil {
-		sq.Logger.Error(err)
+		sq.Logger.Errorf("got an unknown item of type %T in the queue", obj)
 		return true
 	}
+
+	err := action.Sync(sq.KubeClient, sq.Metrics, sq.BackendName)
+
+	// We successfully handled the action, so we can forget the item and keep going.
+	if err == nil {
+		sq.Workqueue.Forget(obj)
+		sq.Metrics.QueueSizeGaugeMetric(sq.BackendName, sq.ClusterType, sq.Workqueue.Len())
+		sq.Logger.Infof("Successfully handled: %s", action)
+		return true
+	}
+
+	// If there was an error handling the item, we will retry up to
+	// queueMaxRetries times.
+	if sq.Workqueue.NumRequeues(obj) < queueMaxRetries {
+		sq.Logger.Infof("Error handling %s: %v. Requeuing.", action, err)
+		sq.Workqueue.AddRateLimited(obj)
+		sq.Metrics.QueueSizeGaugeMetric(sq.BackendName, sq.ClusterType, sq.Workqueue.Len())
+		return true
+	}
+
+	// We tried `queueMaxRetries` times but still failed. Dropping the item from
+	// the queue.
+	sq.Workqueue.Forget(obj)
+	sq.Logger.Errorf("Dropping %s out of the queue because we failed to handle the item %d times: %v", action, queueMaxRetries, err)
+	sq.Metrics.QueueSizeGaugeMetric(sq.BackendName, sq.ClusterType, sq.Workqueue.Len())
 	return true
 }

--- a/discovery/pkg/sync/queue.go
+++ b/discovery/pkg/sync/queue.go
@@ -127,8 +127,9 @@ func (sq *Queue) processNextWorkItem() bool {
 
 	// If there was an error handling the item, we will retry up to
 	// queueMaxRetries times.
-	if sq.Workqueue.NumRequeues(obj) < queueMaxRetries {
-		sq.Logger.Infof("Error handling %s: %v. Requeuing.", action, err)
+	numRequeues := sq.Workqueue.NumRequeues(obj)
+	if numRequeues < queueMaxRetries {
+		sq.Logger.Errorf("Error handling %s: %v. Number of requeues: %d. Requeuing.", action, err, numRequeues)
 		sq.Workqueue.AddRateLimited(obj)
 		sq.Metrics.QueueSizeGaugeMetric(sq.BackendName, sq.ClusterType, sq.Workqueue.Len())
 		return true

--- a/discovery/pkg/sync/queue_test.go
+++ b/discovery/pkg/sync/queue_test.go
@@ -39,7 +39,7 @@ func TestQueueStopsRetryingAfterSuccess(t *testing.T) {
 	var createAttempts int
 	client.PrependReactor("create", "services", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		err := errors.New("fake error")
-		if createAttempts == 2 {
+		if createAttempts == 1 {
 			err = nil
 		}
 		createAttempts++
@@ -59,8 +59,8 @@ func TestQueueStopsRetryingAfterSuccess(t *testing.T) {
 	time.Sleep(1 * time.Second)
 	close(stop)
 
-	// Assert that we tried three times
-	assert.Equal(t, 3, createAttempts)
+	// Assert that we tried twice
+	assert.Equal(t, 2, createAttempts)
 	assert.Equal(t, 0, q.Workqueue.Len())
 }
 

--- a/discovery/pkg/sync/queue_test.go
+++ b/discovery/pkg/sync/queue_test.go
@@ -1,0 +1,91 @@
+package sync
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/heptio/gimbal/discovery/pkg/metrics"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestQueueSuccessfulSync(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	var createAttempts int
+	client.PrependReactor("create", "services", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		createAttempts++
+		return true, nil, nil
+	})
+	q := NewQueue(logrus.New(), "backend", "kubernetes", client, 4, metrics.NewMetrics())
+	stop := make(chan struct{})
+	go q.Run(stop)
+
+	q.Enqueue(AddServiceAction(&v1.Service{}))
+	// TODO(abrand): replace sleeps with some other signal
+	time.Sleep(1 * time.Second)
+	close(stop)
+
+	assert.Equal(t, 1, createAttempts)
+	assert.Equal(t, 0, q.Workqueue.Len())
+}
+
+func TestQueueStopsRetryingAfterSuccess(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	var createAttempts int
+	client.PrependReactor("create", "services", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		err := errors.New("fake error")
+		if createAttempts == 2 {
+			err = nil
+		}
+		createAttempts++
+		return true, nil, err
+	})
+
+	// Start the queue
+	q := NewQueue(logrus.New(), "backend", "kubernetes", client, 4, metrics.NewMetrics())
+	stop := make(chan struct{})
+	go q.Run(stop)
+
+	// Enqueue an add service that will always fail
+	q.Enqueue(AddServiceAction(&v1.Service{}))
+
+	// Wait until we process it
+	// TODO(abrand): replace sleeps with some other signal
+	time.Sleep(1 * time.Second)
+	close(stop)
+
+	// Assert that we tried three times
+	assert.Equal(t, 3, createAttempts)
+	assert.Equal(t, 0, q.Workqueue.Len())
+}
+
+func TestQueueMaxRetries(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	var createAttempts int
+	client.PrependReactor("create", "services", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		createAttempts++
+		return true, nil, errors.New("fake error")
+	})
+
+	// Start the queue
+	q := NewQueue(logrus.New(), "backend", "kubernetes", client, 4, metrics.NewMetrics())
+	stop := make(chan struct{})
+	go q.Run(stop)
+
+	// Enqueue an add service that will always fail
+	q.Enqueue(AddServiceAction(&v1.Service{}))
+
+	// Wait until we process it
+	// TODO(abrand): replace sleeps with some other signal
+	time.Sleep(1 * time.Second)
+	close(stop)
+
+	// Assert that we tried five times and that we finally dropped it
+	assert.Equal(t, queueMaxRetries, createAttempts)
+	assert.Equal(t, 0, q.Workqueue.Len())
+}


### PR DESCRIPTION
Updates #134

I propose we open another issue for spec'ing a new metric that will keep track of the number of retries.

```
The client-go workqueue expects the user to mark any item that needs to
be retried as "dirty". That is, on failure, the item must be re-added to
the queue for reprocessing at a later time.

The item is added to the queue via AddRateLimited, which will add the
item once the rate limiter says it's okay.

Signed-off-by: Alexander Brand <alexbrand09@gmail.com>
```