### PR TITLE
Envoy daemonset does rollingUpdate when modified

### DIFF
--- a/deployment/contour/03-envoy.yaml
+++ b/deployment/contour/03-envoy.yaml
@@ -6,6 +6,10 @@ metadata:
   name: envoy
   namespace: gimbal-contour
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
   selector:
     matchLabels:
       app: envoy


### PR DESCRIPTION
This sets the Envoy Daemonset to perform a rolling update when the manifest is changed. It also defines a 10% `maxUnavailable` which means it can potentially roll more than one pod at a time depending on how many total pods exist in the environment.

Signed-off-by: Steve Sloka <steves@heptio.com>