### PR TITLE
discovery/openstack: set TargetPort and ignore sort order for update detection

### DIFF
--- a/discovery/pkg/openstack/diff.go
+++ b/discovery/pkg/openstack/diff.go
@@ -36,8 +36,11 @@ func diffServices(desired, current []v1.Service) (add, update, del []v1.Service)
 
 	for _, currentSvc := range current {
 		for _, desiredSvc := range desired {
-			if !serviceEqualsDetail(&currentSvc, &desiredSvc) {
-				update = append(update, desiredSvc)
+			if serviceEquals(&currentSvc, &desiredSvc) {
+				if !serviceEqualsDetail(&currentSvc, &desiredSvc) {
+					update = append(update, desiredSvc)
+				}
+				break
 			}
 		}
 	}
@@ -59,8 +62,11 @@ func diffEndpoints(desired, current []v1.Endpoints) (add, update, del []v1.Endpo
 
 	for _, currentEp := range current {
 		for _, desiredEp := range desired {
-			if !endpointEqualsDetail(&currentEp, &desiredEp) {
-				update = append(update, desiredEp)
+			if endpointEquals(&currentEp, &desiredEp) {
+				if !endpointEqualsDetail(&currentEp, &desiredEp) {
+					update = append(update, desiredEp)
+				}
+				break
 			}
 		}
 	}

--- a/discovery/pkg/openstack/diff_test.go
+++ b/discovery/pkg/openstack/diff_test.go
@@ -140,6 +140,73 @@ func TestDiffServices(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "order doesn't matter for update",
+			current: []v1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "finance",
+						Name:      "service1",
+					},
+					Spec: v1.ServiceSpec{
+						Ports: []v1.ServicePort{
+							{
+								Name:     "http",
+								Port:     80,
+								Protocol: "TCP",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "finance",
+						Name:      "service2",
+					},
+					Spec: v1.ServiceSpec{
+						Ports: []v1.ServicePort{
+							{
+								Name:     "http",
+								Port:     80,
+								Protocol: "TCP",
+							},
+						},
+					},
+				},
+			},
+			desired: []v1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "finance",
+						Name:      "service2",
+					},
+					Spec: v1.ServiceSpec{
+						Ports: []v1.ServicePort{
+							{
+								Name:     "http",
+								Port:     80,
+								Protocol: "TCP",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "finance",
+						Name:      "service1",
+					},
+					Spec: v1.ServiceSpec{
+						Ports: []v1.ServicePort{
+							{
+								Name:     "http",
+								Port:     80,
+								Protocol: "TCP",
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -285,6 +352,101 @@ func TestDiffEndpoints(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "finance",
 						Name:      "production",
+					},
+					Subsets: []v1.EndpointSubset{
+						{
+							Addresses: []v1.EndpointAddress{
+								{
+									IP: "1.2.3.4",
+								},
+							},
+							Ports: []v1.EndpointPort{
+								{
+									Name:     "svc1",
+									Port:     80,
+									Protocol: v1.ProtocolTCP,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "order doesn't matter for update",
+			current: []v1.Endpoints{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "finance",
+						Name:      "endpoints1",
+					},
+					Subsets: []v1.EndpointSubset{
+						{
+							Addresses: []v1.EndpointAddress{
+								{
+									IP: "1.2.3.4",
+								},
+							},
+							Ports: []v1.EndpointPort{
+								{
+									Name:     "svc1",
+									Port:     80,
+									Protocol: v1.ProtocolTCP,
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "finance",
+						Name:      "endpoints2",
+					},
+					Subsets: []v1.EndpointSubset{
+						{
+							Addresses: []v1.EndpointAddress{
+								{
+									IP: "1.2.3.4",
+								},
+							},
+							Ports: []v1.EndpointPort{
+								{
+									Name:     "svc1",
+									Port:     80,
+									Protocol: v1.ProtocolTCP,
+								},
+							},
+						},
+					},
+				},
+			},
+			desired: []v1.Endpoints{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "finance",
+						Name:      "endpoints2",
+					},
+					Subsets: []v1.EndpointSubset{
+						{
+							Addresses: []v1.EndpointAddress{
+								{
+									IP: "1.2.3.4",
+								},
+							},
+							Ports: []v1.EndpointPort{
+								{
+									Name:     "svc1",
+									Port:     80,
+									Protocol: v1.ProtocolTCP,
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "finance",
+						Name:      "endpoints1",
 					},
 					Subsets: []v1.EndpointSubset{
 						{

--- a/discovery/pkg/openstack/reconciler.go
+++ b/discovery/pkg/openstack/reconciler.go
@@ -103,7 +103,7 @@ func (r *Reconciler) reconcile() {
 	start := time.Now()
 
 	log := r.Logger
-	log.Debugln("reconciling openstack load balancers")
+	log.Info("reconciling load balancers")
 	// Get all the openstack tenants that must be synced
 	projects, err := r.ProjectLister.ListProjects()
 	if err != nil {

--- a/discovery/pkg/openstack/translate.go
+++ b/discovery/pkg/openstack/translate.go
@@ -24,6 +24,7 @@ import (
 	"github.com/heptio/gimbal/discovery/pkg/translator"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // returns a kubernetes service for each load balancer in the slice
@@ -116,9 +117,14 @@ func serviceName(lb loadbalancers.LoadBalancer) string {
 func servicePort(listener *listeners.Listener) v1.ServicePort {
 	pn := portName(listener)
 	return v1.ServicePort{
-		Name:     pn,
-		Port:     int32(listener.ProtocolPort),
-		Protocol: v1.ProtocolTCP, // only support TCP
+		Name: pn,
+		Port: int32(listener.ProtocolPort),
+		// The K8s API server sets this field on service creation. By setting
+		// this ourselves, we prevent the discoverer from thinking it needs to
+		// perform an update every time it compares the translated object with
+		// the one that exists in gimbal.
+		TargetPort: intstr.FromInt(listener.ProtocolPort),
+		Protocol:   v1.ProtocolTCP, // only support TCP
 	}
 }
 

--- a/discovery/pkg/openstack/translate_test.go
+++ b/discovery/pkg/openstack/translate_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/pools"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func TestKubeServices(t *testing.T) {
@@ -168,9 +169,10 @@ func TestKubeServices(t *testing.T) {
 						"gimbal.heptio.com/load-balancer-name": "stocks"},
 					[]v1.ServicePort{
 						{
-							Name:     "port-80",
-							Port:     80,
-							Protocol: v1.ProtocolTCP,
+							Name:       "port-80",
+							Port:       80,
+							TargetPort: intstr.FromInt(80),
+							Protocol:   v1.ProtocolTCP,
 						},
 					}),
 			},
@@ -191,9 +193,10 @@ func TestKubeServices(t *testing.T) {
 						"gimbal.heptio.com/load-balancer-name": "stocks"},
 					[]v1.ServicePort{
 						{
-							Name:     "port-80",
-							Port:     80,
-							Protocol: v1.ProtocolTCP,
+							Name:       "port-80",
+							Port:       80,
+							TargetPort: intstr.FromInt(80),
+							Protocol:   v1.ProtocolTCP,
 						},
 					}),
 			},
@@ -214,14 +217,16 @@ func TestKubeServices(t *testing.T) {
 						"gimbal.heptio.com/load-balancer-name": "stocks"},
 					[]v1.ServicePort{
 						{
-							Name:     "port-80",
-							Port:     80,
-							Protocol: v1.ProtocolTCP,
+							Name:       "port-80",
+							Port:       80,
+							TargetPort: intstr.FromInt(80),
+							Protocol:   v1.ProtocolTCP,
 						},
 						{
-							Name:     "port-443",
-							Port:     443,
-							Protocol: v1.ProtocolTCP,
+							Name:       "port-443",
+							Port:       443,
+							TargetPort: intstr.FromInt(443),
+							Protocol:   v1.ProtocolTCP,
 						},
 					}),
 			},
@@ -242,14 +247,16 @@ func TestKubeServices(t *testing.T) {
 						"gimbal.heptio.com/load-balancer-name": ""},
 					[]v1.ServicePort{
 						{
-							Name:     "port-80",
-							Port:     80,
-							Protocol: v1.ProtocolTCP,
+							Name:       "port-80",
+							Port:       80,
+							TargetPort: intstr.FromInt(80),
+							Protocol:   v1.ProtocolTCP,
 						},
 						{
-							Name:     "port-443",
-							Port:     443,
-							Protocol: v1.ProtocolTCP,
+							Name:       "port-443",
+							Port:       443,
+							TargetPort: intstr.FromInt(443),
+							Protocol:   v1.ProtocolTCP,
 						},
 					}),
 			},


### PR DESCRIPTION
Fixes #95 

There were two problems which have been addressed:

1. The Kubernetes API server sets the target port to the service port on creation. We were not setting the target port when translating the object, so there would always be a difference between the service that we translated and the service that exists in the gimbal cluster. The fix for this is to set the target port in the discoverer during the translation process.

2. Our diff code assumed that the slice of services/endpoints we got from the gimbal cluster were sorted in the same way as the slice of services/endpoints we got from the backend (after translation). Instead, we now perform the correct comparison by first finding the right service (or endpoint) in the slice of backend services (or endpoints), and then comparing service-x with service-x.