### PR TITLE
discovery: do not count the default kubernetes svc as an upstream svc

### DIFF
--- a/discovery/pkg/k8s/controller_test.go
+++ b/discovery/pkg/k8s/controller_test.go
@@ -85,7 +85,7 @@ var serviceTests = []struct {
 			},
 		},
 		expected:              0,
-		expectedServicesCount: 1,
+		expectedServicesCount: 0,
 	},
 	{
 		name: "kubernetes service diff namespace",

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -108,7 +108,7 @@ Detailed documentation on stats within Envoy is available on their site: https:/
     - backendname
     - errortype: type of error encountered
     - backendtype
-  - **gimbal_discoverer_upstream_services_total (gauge):** Total number of services in the upstream backend cluster
+  - **gimbal_discoverer_upstream_services_total (gauge):** Total number of services in the backend cluster (Kubernetes: The default kubernetes service is not counted).
     - backendname
     - namespace
     - backendtype


### PR DESCRIPTION
Fixes #155 

```
The kubernetes service is ignored by the discoverer when replicating
services into the gimbal cluster. Thus, the upstream service count
metric should not include the kubernetes service.
```