### PR TITLE
pkg/sync: only set success metrics when item is processed successfully

### DIFF
--- a/discovery/pkg/sync/queue.go
+++ b/discovery/pkg/sync/queue.go
@@ -115,18 +115,18 @@ func (sq *Queue) processNextWorkItem() bool {
 	}
 
 	err := action.Sync(sq.KubeClient, sq.Logger)
-	if err != nil {
-		action.SetMetricError(sq.Metrics)
-	}
-	action.SetMetrics(sq.KubeClient, sq.Metrics, sq.Logger)
 
 	// We successfully handled the action, so we can forget the item and keep going.
 	if err == nil {
 		sq.Workqueue.Forget(obj)
+		action.SetMetrics(sq.KubeClient, sq.Metrics, sq.Logger)
 		sq.Metrics.QueueSizeGaugeMetric(sq.Workqueue.Len())
 		sq.Logger.Infof("Successfully handled: %s", action)
 		return true
 	}
+
+	// An error ocurred. Set the error metrics.
+	action.SetMetricError(sq.Metrics)
 
 	// If there was an error handling the item, we will retry up to
 	// queueMaxRetries times.


### PR DESCRIPTION
With this change, the metrics are only set when we have successfully handled an item. Otherwise, the metrics could be misleading. For example, if we fail to sync an endpoints object, we would still increment the `gimbal_discoverer_replicated_endpoints_total` metric, even though the endpoints object was not replicated.

The downside, which I am still unsure whether it is a problem or not, is that the timestamp metric will only be updated when the item is processed successfully.

Fixes #154