### PR TITLE
Minor cleanup of deployment docs

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -15,10 +15,6 @@
     - [Deploy Grafana](#deploy-grafana)
         - [Quick start](#quick-start-1)
         - [Access the Grafana UI](#access-the-grafana-ui)
-        - [Configure Grafana](#configure-grafana)
-            - [Configure datasource](#configure-datasource)
-            - [Dashboards](#dashboards)
-                - [Add Sample Kubernetes Dashboard](#add-sample-kubernetes-dashboard)
     - [Validation](#validation)
         - [Discovery cluster](#discovery-cluster)
         - [Gimbal cluster](#gimbal-cluster)
@@ -154,11 +150,7 @@ $ kubectl create secret generic grafana -n gimbal-monitoring \
 $ kubectl port-forward $(kubectl get pods -l app=grafana -n gimbal-monitoring -o jsonpath='{.items[0].metadata.name}') 3000 -n gimbal-monitoring
 ```
 
-then go to [http://localhost:3000](http://localhost:3000) in your browser. The username is `admin`.
-
-#### Configure dashboards
-
-Dashboards for Envoy and the Discovery components are included as part of the sample Grafana deployment.
+then go to [http://localhost:3000](http://localhost:3000) in your browser. The username and password are from when you defined the Grafana secret in the previous step.
 
 ## Validation
 

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -156,31 +156,9 @@ $ kubectl port-forward $(kubectl get pods -l app=grafana -n gimbal-monitoring -o
 
 then go to [http://localhost:3000](http://localhost:3000) in your browser. The username is `admin`.
 
-### Configure Grafana
-
-Grafana requires some configuration after it's deployed.
-
-#### Configure datasource
-
-1. On the main Grafana page, click **Add Datasource**
-2. For **Name** enter _prometheus_
-3. In the **Type** selector, choose _Prometheus_ 
-4. For the URL, enter `http://prometheus:9090`
-5. Click **Save & Test**
-6. Look for the message box _Data source is working_
-
 #### Configure dashboards
 
 Dashboards for Envoy and the Discovery components are included as part of the sample Grafana deployment.
-
-##### Add Sample Kubernetes Dashboard
-
-Add a sample dashboard to validate that the data source is collecting data:
-
-1. On the main page, click the plus icon and choose **Import dashboard**
-2. Enter _1621_ in the first box
-3. In the **prometheus** section, choose the datasource that you just created
-4. Click **Import**
 
 ## Validation
 
@@ -209,7 +187,7 @@ NAME            READY     STATUS    RESTARTS   AGE
 contour-lq6mm   2/2       Running   0          5h
 
 # Verify discovered services
-$ kubectl get svc -l gimbal.heptio.com/backend=node02 
+$ kubectl get svc -l gimbal.heptio.com/backend
 NAME                TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE
 nginx-node02        ClusterIP   None         <none>        80/TCP    17m
 kuard-node02        ClusterIP   None         <none>        80/TCP    17m


### PR DESCRIPTION
* Grafana no longer needs to be configured to talk to prometheus
* Grafana dashboards are pre-configured
* Change doc label selector to pickup all backends

Signed-off-by: Ross Kukulinski <ross@kukulinski.com>