### PR TITLE
discovery: split cluster name validation to missing and format errors…

### DIFF
--- a/discovery/cmd/openstack-discoverer/main.go
+++ b/discovery/cmd/openstack-discoverer/main.go
@@ -104,9 +104,13 @@ func main() {
 	// Log info metric
 	discovererMetrics.DiscovererInfoMetric(buildinfo.Version)
 
-	// Validate cluster name
+	// Validate cluster name present
+	if backendName == "" {
+		log.Fatalf("The Kubernetes cluster name must be provided using the `--backend-name` flag")
+	}
+	// Validate cluster name format
 	if util.IsInvalidBackendName(backendName) {
-		log.Fatalf("The Kubernetes cluster name must be provided using the `--backend-name` flag or the one passed is invalid")
+		log.Fatalf("The Kubernetes cluster name is invalid.  Valid names must contain only lowercase letters, numbers, and hyphens ('-').  They must start with a letter, and must not end with a hyphen")
 	}
 	log.Infof("BackendName is: %s", backendName)
 

--- a/discovery/pkg/util/util_test.go
+++ b/discovery/pkg/util/util_test.go
@@ -46,17 +46,27 @@ func TestTranslateService(t *testing.T) {
 			expected:    true,
 		},
 		{
-			name:        "multiple underscores",
+			name:        "ends with number",
+			backendName: "mycluster1",
+			expected:    false,
+		},
+		{
+			name:        "multiple hyphens",
 			backendName: "my----cluster",
 			expected:    false,
 		},
 		{
-			name:        "can't start with underscores",
+			name:        "can't start with hyphen",
 			backendName: "-mycluster",
 			expected:    true,
 		},
 		{
-			name:        "can't end with underscores",
+			name:        "can't start with number",
+			backendName: "0mycluster",
+			expected:    true,
+		},
+		{
+			name:        "can't end with hyphen",
 			backendName: "mycluster-",
 			expected:    true,
 		},


### PR DESCRIPTION
Split out the validation checks to provide more specific error messages in the cases of missing or invalid  `--backend-name` parameter. Fixes #167 