### PR TITLE
discovery: set annotation on discovered services and endpoints

### DIFF
--- a/discovery/pkg/k8s/translate.go
+++ b/discovery/pkg/k8s/translate.go
@@ -22,9 +22,10 @@ import (
 func translateService(svc *v1.Service, backendName string) *v1.Service {
 	newService := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: svc.Namespace,
-			Name:      translator.BuildDiscoveredName(backendName, svc.Name),
-			Labels:    translator.AddGimbalLabels(backendName, svc.ObjectMeta.Name, svc.ObjectMeta.Labels),
+			Namespace:   svc.Namespace,
+			Name:        translator.BuildDiscoveredName(backendName, svc.Name),
+			Labels:      translator.AddGimbalLabels(backendName, svc.ObjectMeta.Name, svc.ObjectMeta.Labels),
+			Annotations: svc.Annotations,
 		},
 		Spec: v1.ServiceSpec{
 			ClusterIP: "None",
@@ -44,9 +45,10 @@ func translateService(svc *v1.Service, backendName string) *v1.Service {
 func translateEndpoints(endpoints *v1.Endpoints, backendName string) *v1.Endpoints {
 	newEndpoint := &v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: endpoints.Namespace,
-			Name:      translator.BuildDiscoveredName(backendName, endpoints.Name),
-			Labels:    translator.AddGimbalLabels(backendName, endpoints.ObjectMeta.Name, endpoints.ObjectMeta.Labels),
+			Namespace:   endpoints.Namespace,
+			Name:        translator.BuildDiscoveredName(backendName, endpoints.Name),
+			Labels:      translator.AddGimbalLabels(backendName, endpoints.ObjectMeta.Name, endpoints.ObjectMeta.Labels),
+			Annotations: endpoints.Annotations,
 		},
 		Subsets: endpoints.Subsets,
 	}

--- a/discovery/pkg/k8s/translate_test.go
+++ b/discovery/pkg/k8s/translate_test.go
@@ -35,9 +35,10 @@ func TestTranslateService(t *testing.T) {
 			backendName: "cluster1",
 			service: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "default",
-					Name:      "kuard",
-					Labels:    map[string]string{"app": "kuard"},
+					Namespace:   "default",
+					Name:        "kuard",
+					Labels:      map[string]string{"app": "kuard"},
+					Annotations: map[string]string{"foo": "bar"},
 				},
 				Spec: v1.ServiceSpec{
 					ClusterIP: "10.99.179.252",
@@ -48,9 +49,10 @@ func TestTranslateService(t *testing.T) {
 			},
 			expected: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "default",
-					Name:      "cluster1-kuard",
-					Labels:    map[string]string{"app": "kuard", "gimbal.heptio.com/backend": "cluster1", "gimbal.heptio.com/service": "kuard"},
+					Namespace:   "default",
+					Name:        "cluster1-kuard",
+					Labels:      map[string]string{"app": "kuard", "gimbal.heptio.com/backend": "cluster1", "gimbal.heptio.com/service": "kuard"},
+					Annotations: map[string]string{"foo": "bar"},
 				},
 				Spec: v1.ServiceSpec{
 					ClusterIP: "None",
@@ -64,9 +66,10 @@ func TestTranslateService(t *testing.T) {
 			backendName: "cluster1",
 			service: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "default",
-					Name:      "kuard",
-					Labels:    map[string]string{"app": "kuard"},
+					Namespace:   "default",
+					Name:        "kuard",
+					Labels:      map[string]string{"app": "kuard"},
+					Annotations: map[string]string{"foo": "bar"},
 				},
 				Spec: v1.ServiceSpec{
 					ClusterIP: "10.99.179.252",
@@ -80,9 +83,10 @@ func TestTranslateService(t *testing.T) {
 			},
 			expected: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "default",
-					Name:      "cluster1-kuard",
-					Labels:    map[string]string{"app": "kuard", "gimbal.heptio.com/backend": "cluster1", "gimbal.heptio.com/service": "kuard"},
+					Namespace:   "default",
+					Name:        "cluster1-kuard",
+					Labels:      map[string]string{"app": "kuard", "gimbal.heptio.com/backend": "cluster1", "gimbal.heptio.com/service": "kuard"},
+					Annotations: map[string]string{"foo": "bar"},
 				},
 				Spec: v1.ServiceSpec{
 					ClusterIP: "None",
@@ -116,9 +120,10 @@ func TestTranslateEndpoints(t *testing.T) {
 			backendName: "cluster1",
 			endpoints: &v1.Endpoints{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "default",
-					Name:      "kuard",
-					Labels:    map[string]string{"app": "kuard"},
+					Namespace:   "default",
+					Name:        "kuard",
+					Labels:      map[string]string{"app": "kuard"},
+					Annotations: map[string]string{"foo": "bar"},
 				},
 				Subsets: []v1.EndpointSubset{
 					{
@@ -129,9 +134,10 @@ func TestTranslateEndpoints(t *testing.T) {
 			},
 			expected: &v1.Endpoints{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "default",
-					Name:      "cluster1-kuard",
-					Labels:    map[string]string{"app": "kuard", "gimbal.heptio.com/backend": "cluster1", "gimbal.heptio.com/service": "kuard"},
+					Namespace:   "default",
+					Name:        "cluster1-kuard",
+					Labels:      map[string]string{"app": "kuard", "gimbal.heptio.com/backend": "cluster1", "gimbal.heptio.com/service": "kuard"},
+					Annotations: map[string]string{"foo": "bar"},
 				},
 				Subsets: []v1.EndpointSubset{
 					{


### PR DESCRIPTION
When discovering services and endpoints, include the annotations as well.

Fixes #178 

