### PR TITLE
Update contour RBAC to support writing status

### DIFF
--- a/deployment/contour/02-rbac.yaml
+++ b/deployment/contour/02-rbac.yaml
@@ -55,3 +55,6 @@ rules:
   - get
   - list
   - watch
+  - put
+  - post
+  - patch


### PR DESCRIPTION
Signed-off-by: Ross Kukulinski <ross@kukulinski.com>

Contour RBAC policies for IngressRoute CRD were updated to include the ability to update the status field.