### PR TITLE
Remove debug listener from Deployment

### DIFF
--- a/deployment/contour/03-contour.yaml
+++ b/deployment/contour/03-contour.yaml
@@ -37,8 +37,6 @@ spec:
         - $(CONTOUR_SERVICE_PORT)
         - --envoy-http-port
         - "80"
-        - --http-address
-        - "0.0.0.0"
         command: ["contour"]
         image: gcr.io/heptio-images/contour:v0.6.0-beta.2
         imagePullPolicy: Always


### PR DESCRIPTION
Once (https://github.com/heptio/contour/pull/593) lands the /metrics port will be exposed directly without needing to expose the debug ports. This PR updates the deployment to remove the debug interface. 

Signed-off-by: Steve Sloka <steves@heptio.com>