### PR TITLE
deployment/grafana: sum the replicated services by backend

### DIFF
--- a/deployment/grafana/02-grafana-configmap.yaml
+++ b/deployment/grafana/02-grafana-configmap.yaml
@@ -507,7 +507,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(gimbal_discoverer_replicated_services_total{namespace=~\"$Namespace\",backendname=~\"$Backend\"}) by (backendname)",
+              "expr": "sum(gimbal_discoverer_replicated_services_total{namespace=~\"$Namespace\",backendname=~\"$Backend\"}) by (backendname)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Backend: {{ backendname }} ",


### PR DESCRIPTION
Update the replicated services by backend panel to use sum() instead of avg()

Fixes #191 