### PR TITLE
Change OpenStack Discoverer listen port for LivenessProve

### DIFF
--- a/deployment/gimbal-discoverer/02-openstack-discoverer.yaml
+++ b/deployment/gimbal-discoverer/02-openstack-discoverer.yaml
@@ -60,7 +60,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /healthz
-              port: 8080
+              port: 8000
             initialDelaySeconds: 30
             periodSeconds: 60
       volumes:

--- a/discovery/cmd/openstack-discoverer/main.go
+++ b/discovery/cmd/openstack-discoverer/main.go
@@ -222,7 +222,7 @@ func main() {
 
 	go func() {
 		http.HandleFunc("/healthz", healthzHandler)
-		log.Fatal(http.ListenAndServe("127.0.0.1:8080", nil))
+		log.Fatal(http.ListenAndServe("127.0.0.1:8000", nil))
 		<-stopCh
 		log.Info("Shutting down healthz endpoint...")
 	}()


### PR DESCRIPTION
I tried to deploy OpenStack Discoverer, but failed to start it cause of conflict between Prometheus port and LivenessProve port. Error messages are below.
```
time="2018-08-22T02:48:33Z" level=info msg="Gimbal OpenStack Discoverer Starting up..."
time="2018-08-22T02:48:33Z" level=info msg="Version: v0.3.0-beta.3"
time="2018-08-22T02:48:33Z" level=info msg="Backend name: os01"
time="2018-08-22T02:48:33Z" level=info msg="Number of queue worker threads: 2"
time="2018-08-22T02:48:33Z" level=info msg="Reconciliation period: 30s"
time="2018-08-22T02:48:33Z" level=info msg="Gimbal kubernetes client QPS: 5"
time="2018-08-22T02:48:33Z" level=info msg="Gimbal kubernetes client burst: 10"
time="2018-08-22T02:48:33Z" level=info msg="BackendName is: os01"
time="2018-08-22T02:48:33Z" level=info msg="Using InCluster k8s config"
time="2018-08-22T02:48:33Z" level=warning msg="The OS_USER_DOMAIN_NAME environment variable was not set. Using \"Default\" as the OpenStack user domain name."
time="2018-08-22T02:48:33Z" level=debug msg="Request URL: https://<MY-OPENSTACK-SERVER>/v3/auth/tokens"
time="2018-08-22T02:48:33Z" level=debug msg="-- API Latency: 475"
time="2018-08-22T02:48:33Z" level=debug msg="-- Response Status: 201 Created"
time="2018-08-22T02:48:33Z" level=info msg="Starting reconciler"
time="2018-08-22T02:48:33Z" level=info msg="Listening for Prometheus metrics on port: 8080"
time="2018-08-22T02:48:33Z" level=fatal msg="listen tcp :8080: bind: address already in use"
```

My suggestion is to change port number for LivenessProve to another (not 8080) port.

Related: https://github.com/heptio/gimbal/pull/202

Signed-off-by: yutaokaz <yutaokaz@yahoo.co.jp>