### PR TITLE
Add flag to have openstack client re-auth when token expires

### DIFF
--- a/discovery/cmd/openstack-discoverer/main.go
+++ b/discovery/cmd/openstack-discoverer/main.go
@@ -171,6 +171,7 @@ func main() {
 		Password:         password,
 		DomainName:       userDomainName,
 		TenantName:       tenantName,
+		AllowReauth:      true,
 	}
 
 	if err := gopheropenstack.Authenticate(osClient, osAuthOptions); err != nil {


### PR DESCRIPTION
Fixes #207 by allowing the openstack client to automatically refresh the auth token. Also, if the auth fails more the 3 times, then the app will quit and be restarted. 

Signed-off-by: Steve Sloka <steves@heptio.com>