### PR TITLE
Add a build badge on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Gimbal
 
+[![Build Status](https://travis-ci.org/heptio/gimbal.svg?branch=master)](https://travis-ci.org/heptio/gimbal)
+
 Maintainers: [Heptio](https://github.com/heptio)
 
 ## Overview


### PR DESCRIPTION
Hi,
I added Travis CI build badge on README.md in order to check the health of the code easily.