### PR TITLE
kubernetes discoverer now skips services with gimbal label backend

### DIFF
--- a/discovery/pkg/k8s/controller_test.go
+++ b/discovery/pkg/k8s/controller_test.go
@@ -88,6 +88,28 @@ var serviceTests = []struct {
 		expectedServicesCount: 0,
 	},
 	{
+		name: "kubernetes service gimbal label backend",
+		service: &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "kubernetes",
+				Namespace: "default",
+				Labels: map[string]string{
+					"gimbal.heptio.com/backend": "zzzzz",
+				},
+			},
+			Spec: v1.ServiceSpec{
+				Ports: []v1.ServicePort{
+					{
+						Name: "http",
+						Port: 80,
+					},
+				},
+			},
+		},
+		expected:              0,
+		expectedServicesCount: 0,
+	},
+	{
 		name: "kubernetes service diff namespace",
 		service: &v1.Service{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
kubernetes discoverer now skips services with gimbal label backend - fixes #138 

Before:

```
discovery (fix/issue_138) $ go run cmd/kubernetes-discoverer/main.go \
>     --gimbal-kubecfg-file=/Users/name/.kube/config \
>     --discover-kubecfg-file=/Users/name/.kube/config \
>     --backend-name=zzzzzzz \
>     --debug=true
INFO[2018-10-24T11:21:49-07:00] Gimbal Kubernetes Discoverer Starting up...
INFO[2018-10-24T11:21:49-07:00] Version:
INFO[2018-10-24T11:21:49-07:00] Backend name: zzzzzzz
INFO[2018-10-24T11:21:49-07:00] Number of queue worker threads: 2
INFO[2018-10-24T11:21:49-07:00] Resync interval: 30m0s
INFO[2018-10-24T11:21:49-07:00] Gimbal kubernetes client QPS: 5
INFO[2018-10-24T11:21:49-07:00] Gimbal kubernetes client burst: 10
INFO[2018-10-24T11:21:49-07:00] BackendName is: zzzzzzz
INFO[2018-10-24T11:21:49-07:00] Using OutOfCluster k8s config with kubeConfigFile: /Users/name/.kube/config
INFO[2018-10-24T11:21:49-07:00] Using OutOfCluster k8s config with kubeConfigFile: /Users/name/.kube/config
INFO[2018-10-24T11:21:49-07:00] Starting shared informer, resync interval is: 30m0s
INFO[2018-10-24T11:21:49-07:00] Starting k8s controller
INFO[2018-10-24T11:21:49-07:00] Waiting for backend services informer caches to sync
INFO[2018-10-24T11:21:49-07:00] Listening for Prometheus metrics on port: 8080
INFO[2018-10-24T11:21:49-07:00] Waiting for backend endpoints informer caches to sync
INFO[2018-10-24T11:21:49-07:00] Starting queue workers
INFO[2018-10-24T11:21:49-07:00] Started workers
INFO[2018-10-24T11:21:49-07:00] Started workers
INFO[2018-10-24T11:21:49-07:00] Successfully handled: add endpoints 'default/zzzzzzz-zzzzzzz-zzzzzzz-zzzzzzz-zzzzzzz-kuard'
INFO[2018-10-24T11:21:49-07:00] Successfully handled: add endpoints 'default/zzzzzzz-kuard'
INFO[2018-10-24T11:21:49-07:00] Successfully handled: add endpoints 'default/zzzzzzz-default-http-backend'
INFO[2018-10-24T11:21:49-07:00] Successfully handled: add endpoints 'default/zzzzzzz-nginx'
INFO[2018-10-24T11:21:50-07:00] Successfully handled: add service 'default/zzzzzzz-nginx'
INFO[2018-10-24T11:21:50-07:00] Successfully handled: add service 'default/zzzzzzz-default-http-backend'
INFO[2018-10-24T11:21:50-07:00] Successfully handled: add endpoints 'default/zzzzzzz-zzzzzzz-kuard'
INFO[2018-10-24T11:21:51-07:00] Successfully handled: add service 'default/zzzzzzz-kuard'
INFO[2018-10-24T11:21:51-07:00] Successfully handled: add endpoints 'default/zzzzzzz-zzzzzzz-zzzzzzz-zzzzzzz-zzzzzzz-zzzzzzz-kuard'
INFO[2018-10-24T11:21:51-07:00] Successfully handled: add endpoints 'default/zzzzzzz-zzzzzzz-nginx'
INFO[2018-10-24T11:21:51-07:00] Successfully handled: add endpoints 'default/zzzzzzz-zzzzzzz-default-http-backend'
INFO[2018-10-24T11:21:51-07:00] Successfully handled: add service 'default/zzzzzzz-zzzzzzz-nginx'
INFO[2018-10-24T11:21:51-07:00] Successfully handled: add service 'default/zzzzzzz-zzzzzzz-default-http-backend'
INFO[2018-10-24T11:21:51-07:00] Successfully handled: add endpoints 'default/zzzzzzz-zzzzzzz-zzzzzzz-kuard'
INFO[2018-10-24T11:21:52-07:00] Successfully handled: add endpoints 'default/zzzzzzz-zzzzzzz-zzzzzzz-zzzzzzz-zzzzzzz-zzzzzzz-zzzzzzz-kuard'
INFO[2018-10-24T11:21:52-07:00] Successfully handled: add service 'default/zzzzzzz-zzzzzzz-kuard'
INFO[2018-10-24T11:21:52-07:00] Successfully handled: add endpoints 'default/zzzzzzz-zzzzzzz-zzzzzzz-nginx'
INFO[2018-10-24T11:21:52-07:00] Successfully handled: add endpoints 'default/zzzzzzz-zzzzzzz-zzzzzzz-default-http-backend'
INFO[2018-10-24T11:21:53-07:00] Successfully handled: add service 'default/zzzzzzz-zzzzzzz-zzzzzzz-nginx'
INFO[2018-10-24T11:21:53-07:00] Successfully handled: add service 'default/zzzzzzz-zzzzzzz-zzzzzzz-default-http-backend'
INFO[2018-10-24T11:21:54-07:00] Successfully handled: add service 'default/zzzzzzz-zzzzzzz-zzzzzzz-kuard'
INFO[2018-10-24T11:21:54-07:00] Successfully handled: add endpoints 'default/zzzzzzz-zzzzzzz-zzzzzzz-zzzzzzz-kuard'
INFO[2018-10-24T11:21:54-07:00] Successfully handled: add endpoints 'default/zzzzzzz-zzzzzzz-zzzzzzz-zzzzzzz-zb2a07e'
INFO[2018-10-24T11:21:54-07:00] Successfully handled: add endpoints 'default/zzzzzzz-zzzzzzz-zzzzzzz-zzzzzzz-nginx'
INFO[2018-10-24T11:21:55-07:00] Successfully handled: add endpoints 'default/zzzzzzz-zzzzzzz-zzzzzzz-zzzzzzz-default-http-backend'
INFO[2018-10-24T11:21:55-07:00] Successfully handled: add service 'default/zzzzzzz-zzzzzzz-zzzzzzz-zzzzzzz-nginx'
^CINFO[2018-10-24T11:21:55-07:00] Shutting down workers
INFO[2018-10-24T11:21:55-07:00] Shutting down workers

discovery (fix/issue_138) $ kubectl get svc -l gimbal.heptio.com/backend
NAME                                                   TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE
zzzzzzz-default-http-backend                           ClusterIP   None         <none>        80/TCP    56s
zzzzzzz-kuard                                          ClusterIP   None         <none>        80/TCP    56s
zzzzzzz-nginx                                          ClusterIP   None         <none>        80/TCP    56s
zzzzzzz-zzzzzzz-default-http-backend                   ClusterIP   None         <none>        80/TCP    55s
zzzzzzz-zzzzzzz-kuard                                  ClusterIP   None         <none>        80/TCP    55s
zzzzzzz-zzzzzzz-nginx                                  ClusterIP   None         <none>        80/TCP    55s
zzzzzzz-zzzzzzz-zzzzzzz-default-http-backend           ClusterIP   None         <none>        80/TCP    53s
zzzzzzz-zzzzzzz-zzzzzzz-kuard                          ClusterIP   None         <none>        80/TCP    53s
zzzzzzz-zzzzzzz-zzzzzzz-nginx                          ClusterIP   None         <none>        80/TCP    54s
zzzzzzz-zzzzzzz-zzzzzzz-zzzzzzz-default-http-backend   ClusterIP   None         <none>        80/TCP    51s
zzzzzzz-zzzzzzz-zzzzzzz-zzzzzzz-kuard                  ClusterIP   None         <none>        80/TCP    51s
zzzzzzz-zzzzzzz-zzzzzzz-zzzzzzz-nginx                  ClusterIP   None         <none>        80/TCP    51s
```

After:

```
discovery (fix/issue_138) $ go run cmd/kubernetes-discoverer/main.go     --gimbal-kubecfg-file=/Users/name/.kube/config     --discover-kubecfg-file=/Users/name/.kube/config     --backend-name=zzzzzzz     --debug=true
INFO[2018-10-24T11:24:27-07:00] Gimbal Kubernetes Discoverer Starting up...
INFO[2018-10-24T11:24:27-07:00] Version:
INFO[2018-10-24T11:24:27-07:00] Backend name: zzzzzzz
INFO[2018-10-24T11:24:27-07:00] Number of queue worker threads: 2
INFO[2018-10-24T11:24:27-07:00] Resync interval: 30m0s
INFO[2018-10-24T11:24:27-07:00] Gimbal kubernetes client QPS: 5
INFO[2018-10-24T11:24:27-07:00] Gimbal kubernetes client burst: 10
INFO[2018-10-24T11:24:27-07:00] BackendName is: zzzzzzz
INFO[2018-10-24T11:24:27-07:00] Using OutOfCluster k8s config with kubeConfigFile: /Users/name/.kube/config
INFO[2018-10-24T11:24:27-07:00] Using OutOfCluster k8s config with kubeConfigFile: /Users/name/.kube/config
INFO[2018-10-24T11:24:27-07:00] Starting shared informer, resync interval is: 30m0s
INFO[2018-10-24T11:24:27-07:00] Starting k8s controller
INFO[2018-10-24T11:24:27-07:00] Waiting for backend services informer caches to sync
INFO[2018-10-24T11:24:27-07:00] Listening for Prometheus metrics on port: 8080
INFO[2018-10-24T11:24:28-07:00] Waiting for backend endpoints informer caches to sync
INFO[2018-10-24T11:24:28-07:00] Started workers
INFO[2018-10-24T11:24:28-07:00] Starting queue workers
INFO[2018-10-24T11:24:28-07:00] Started workers
INFO[2018-10-24T11:24:28-07:00] Successfully handled: add endpoints 'default/zzzzzzz-nginx'
INFO[2018-10-24T11:24:28-07:00] Successfully handled: add endpoints 'default/zzzzzzz-kuard'
INFO[2018-10-24T11:24:28-07:00] Successfully handled: add endpoints 'default/zzzzzzz-default-http-backend'
INFO[2018-10-24T11:24:28-07:00] Successfully handled: add service 'default/zzzzzzz-default-http-backend'
INFO[2018-10-24T11:24:28-07:00] Successfully handled: add service 'default/zzzzzzz-nginx'
INFO[2018-10-24T11:24:28-07:00] Successfully handled: add service 'default/zzzzzzz-kuard'
^CINFO[2018-10-24T11:24:35-07:00] Shutting down workers
INFO[2018-10-24T11:24:35-07:00] Shutting down workers

discovery (fix/issue_138) $ kubectl get svc -l gimbal.heptio.com/backend
NAME                           TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE
zzzzzzz-default-http-backend   ClusterIP   None         <none>        80/TCP    21s
zzzzzzz-kuard                  ClusterIP   None         <none>        80/TCP    21s
zzzzzzz-nginx                  ClusterIP   None         <none>        80/TCP    21s
```