### PR TITLE
Add whitelist to limit openstack loadbalancers

### DIFF
--- a/discovery/cmd/openstack-discoverer/main.go
+++ b/discovery/cmd/openstack-discoverer/main.go
@@ -52,7 +52,7 @@ var (
 	log                               *logrus.Logger
 	gimbalKubeClientQPS               float64
 	gimbalKubeClientBurst             int
-	openstackProjectWhitelist         string
+	openstackProjectWatchlist         string
 )
 
 var reconciler openstack.Reconciler
@@ -74,7 +74,7 @@ func init() {
 	flag.IntVar(&prometheusListenPort, "prometheus-listen-address", 8080, "The address to listen on for Prometheus HTTP requests")
 	flag.Float64Var(&gimbalKubeClientQPS, "gimbal-client-qps", 5, "The maximum queries per second (QPS) that can be performed on the Gimbal Kubernetes API server")
 	flag.IntVar(&gimbalKubeClientBurst, "gimbal-client-burst", 10, "The maximum number of queries that can be performed on the Gimbal Kubernetes API server during a burst")
-	flag.StringVar(&openstackProjectWhitelist, "openstack-project-whitelist", "", "List of projects to be watched for reconcilation. If empty, load balancers across all projects will be reconciled.")
+	flag.StringVar(&openstackProjectWatchlist, "openstack-project-watchlist", "", "List of projects to be watched for reconcilation. If empty, load balancers across all projects will be reconciled.")
 	flag.Parse()
 }
 
@@ -162,8 +162,8 @@ func main() {
 		transport.RoundTripper = httpTransportWithCA(log, openstackCertificateAuthorityFile)
 	}
 
-	if openstackProjectWhitelist == "" {
-		log.Infof("The OpenStack Whitelist is empty. Syncing all load balancers on the OpenStack cluster.")
+	if openstackProjectWatchlist == "" {
+		log.Infof("The OpenStack Watchlist is empty. Syncing all load balancers on the OpenStack cluster.")
 	}
 
 	osClient.HTTPClient = http.Client{
@@ -197,7 +197,7 @@ func main() {
 	reconciler = openstack.NewReconciler(
 		backendName,
 		clusterType,
-		openstackProjectWhitelist,
+		openstackProjectWatchlist,
 		gimbalKubeClient,
 		reconciliationPeriod,
 		lbv2,

--- a/discovery/cmd/openstack-discoverer/main.go
+++ b/discovery/cmd/openstack-discoverer/main.go
@@ -142,6 +142,10 @@ func main() {
 		log.Warnf("The OS_USER_DOMAIN_NAME environment variable was not set. Using %q as the OpenStack user domain name.", defaultUserDomainName)
 		userDomainName = defaultUserDomainName
 	}
+	watchedProjects := os.Getenv("WATCHED_PROJECTS")
+	if watchedProjects == "" {
+		log.Warnf("The WATCHED_PROJECTS environment variable was not set. Syncing all load balancers on the OpenStack cluster.")
+	}
 
 	// Create and configure client
 	osClient, err := gopheropenstack.NewClient(identityEndpoint)
@@ -191,6 +195,7 @@ func main() {
 	reconciler = openstack.NewReconciler(
 		backendName,
 		clusterType,
+		watchedProjects,
 		gimbalKubeClient,
 		reconciliationPeriod,
 		lbv2,

--- a/discovery/cmd/openstack-discoverer/main.go
+++ b/discovery/cmd/openstack-discoverer/main.go
@@ -142,10 +142,6 @@ func main() {
 		log.Warnf("The OS_USER_DOMAIN_NAME environment variable was not set. Using %q as the OpenStack user domain name.", defaultUserDomainName)
 		userDomainName = defaultUserDomainName
 	}
-	watchedProjects := os.Getenv("WATCHED_PROJECTS")
-	if watchedProjects == "" {
-		log.Warnf("The WATCHED_PROJECTS environment variable was not set. Syncing all load balancers on the OpenStack cluster.")
-	}
 
 	// Create and configure client
 	osClient, err := gopheropenstack.NewClient(identityEndpoint)
@@ -195,7 +191,6 @@ func main() {
 	reconciler = openstack.NewReconciler(
 		backendName,
 		clusterType,
-		watchedProjects,
 		gimbalKubeClient,
 		reconciliationPeriod,
 		lbv2,

--- a/discovery/cmd/openstack-discoverer/main.go
+++ b/discovery/cmd/openstack-discoverer/main.go
@@ -74,7 +74,7 @@ func init() {
 	flag.IntVar(&prometheusListenPort, "prometheus-listen-address", 8080, "The address to listen on for Prometheus HTTP requests")
 	flag.Float64Var(&gimbalKubeClientQPS, "gimbal-client-qps", 5, "The maximum queries per second (QPS) that can be performed on the Gimbal Kubernetes API server")
 	flag.IntVar(&gimbalKubeClientBurst, "gimbal-client-burst", 10, "The maximum number of queries that can be performed on the Gimbal Kubernetes API server during a burst")
-	flag.StringVar(&openstackProjectWhitelist, "openstack-project-whitelist", "", "Whitelist of projects that should be reconciled. If empty, load balancers across all projects will be reconciled.")
+	flag.StringVar(&openstackProjectWhitelist, "openstack-project-whitelist", "", "List of projects to be watched for reconcilation. If empty, load balancers across all projects will be reconciled.")
 	flag.Parse()
 }
 

--- a/discovery/pkg/openstack/reconciler.go
+++ b/discovery/pkg/openstack/reconciler.go
@@ -129,7 +129,7 @@ func (r *Reconciler) reconcile() {
 
 	for _, project := range projects {
 		projectName := project.Name
-		if !contains(whitelist, projectName) {
+		if !contains(whitelist, projectName) && len(whitelist) > 0 {
 			continue
 		}
 

--- a/discovery/pkg/openstack/reconciler.go
+++ b/discovery/pkg/openstack/reconciler.go
@@ -121,22 +121,17 @@ func (r *Reconciler) reconcile() {
 	}
 
 	// import white list
-	tmp := projects[:0]
+	whitelist := []string{}
 	openstackProjectWhitelist := r.OpenstackProjectWhitelist
-	if openstackProjectWhitelist != "" && len(projects) > 0 {
-		watchedProjects := strings.Split(openstackProjectWhitelist, ",")
-		for _, project := range projects {
-			for _, watchedProject := range watchedProjects {
-				if watchedProject == project.Name {
-					tmp = append(tmp, project)
-				}
-			}
-		}
-		projects = tmp
+	if len(openstackProjectWhitelist) > 0 {
+		whitelist = strings.Split(openstackProjectWhitelist, ",")
 	}
 
 	for _, project := range projects {
 		projectName := project.Name
+		if !contains(whitelist, projectName) {
+			continue
+		}
 
 		// Get load balancers that are defined in the project
 		loadbalancers, err := r.ListLoadBalancers(project.ID)
@@ -230,4 +225,13 @@ func (r *Reconciler) reconcileEndpoints(desired []Endpoints, current []Endpoints
 		e := ep
 		r.syncqueue.Enqueue(sync.DeleteEndpointsAction(&e.endpoints, e.upstreamName))
 	}
+}
+
+func contains(s []string, e string) bool {
+	for _, v := range s {
+		if e == v {
+			return true
+		}
+	}
+	return false
 }

--- a/discovery/pkg/openstack/reconciler.go
+++ b/discovery/pkg/openstack/reconciler.go
@@ -15,7 +15,6 @@ package openstack
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -49,8 +48,9 @@ type Reconciler struct {
 	ProjectLister
 
 	// BackendName is the name of the OpenStack cluster
-	BackendName string
-	ClusterType string
+	BackendName     string
+	ClusterType     string
+	WatchedProjects string
 	// GimbalKubeClient is the client of the Kubernetes cluster where Gimbal is running
 	GimbalKubeClient kubernetes.Interface
 	// Interval between reconciliation loops
@@ -68,7 +68,7 @@ type Endpoints struct {
 }
 
 // NewReconciler returns an OpenStack reconciler
-func NewReconciler(backendName, clusterType string, gimbalKubeClient kubernetes.Interface, syncPeriod time.Duration, lbLister LoadBalancerLister,
+func NewReconciler(backendName, clusterType, watchedProjects string, gimbalKubeClient kubernetes.Interface, syncPeriod time.Duration, lbLister LoadBalancerLister,
 	projectLister ProjectLister, log *logrus.Logger, queueWorkers int, metrics localmetrics.DiscovererMetrics) Reconciler {
 
 	return Reconciler{
@@ -80,6 +80,7 @@ func NewReconciler(backendName, clusterType string, gimbalKubeClient kubernetes.
 		Logger:             log,
 		Metrics:            metrics,
 		syncqueue:          sync.NewQueue(log, gimbalKubeClient, queueWorkers, metrics),
+		WatchedProjects:    watchedProjects,
 	}
 }
 
@@ -121,8 +122,9 @@ func (r *Reconciler) reconcile() {
 
 	// import white list
 	tmp := projects[:0]
-	if whitelist, ok := os.LookupEnv("PROJECT_WHITELIST"); ok && len(whitelist) > 0 {
-		desireds := strings.Split(whitelist, ",")
+	watchedProjects := r.WatchedProjects
+	if watchedProjects != "" {
+		desireds := strings.Split(watchedProjects, ",")
 		for _, project := range projects {
 			for _, desired := range desireds {
 				if desired == project.Name {
@@ -131,7 +133,7 @@ func (r *Reconciler) reconcile() {
 			}
 		}
 		projects = tmp
-		log.Info("sync whitelist load balancers")
+		log.Info("sync load balancers on watched projects")
 	} else {
 		log.Info("sync all load balancers")
 	}

--- a/discovery/pkg/openstack/reconciler.go
+++ b/discovery/pkg/openstack/reconciler.go
@@ -50,7 +50,7 @@ type Reconciler struct {
 	// BackendName is the name of the OpenStack cluster
 	BackendName               string
 	ClusterType               string
-	OpenstackProjectWhitelist string
+	OpenstackProjectWatchlist string
 	// GimbalKubeClient is the client of the Kubernetes cluster where Gimbal is running
 	GimbalKubeClient kubernetes.Interface
 	// Interval between reconciliation loops
@@ -68,7 +68,7 @@ type Endpoints struct {
 }
 
 // NewReconciler returns an OpenStack reconciler
-func NewReconciler(backendName, clusterType, openstackProjectWhitelist string, gimbalKubeClient kubernetes.Interface, syncPeriod time.Duration, lbLister LoadBalancerLister,
+func NewReconciler(backendName, clusterType, openstackProjectWatchlist string, gimbalKubeClient kubernetes.Interface, syncPeriod time.Duration, lbLister LoadBalancerLister,
 	projectLister ProjectLister, log *logrus.Logger, queueWorkers int, metrics localmetrics.DiscovererMetrics) Reconciler {
 
 	return Reconciler{
@@ -80,7 +80,7 @@ func NewReconciler(backendName, clusterType, openstackProjectWhitelist string, g
 		Logger:                    log,
 		Metrics:                   metrics,
 		syncqueue:                 sync.NewQueue(log, gimbalKubeClient, queueWorkers, metrics),
-		OpenstackProjectWhitelist: openstackProjectWhitelist,
+		OpenstackProjectWatchlist: openstackProjectWatchlist,
 	}
 }
 
@@ -120,16 +120,16 @@ func (r *Reconciler) reconcile() {
 		return
 	}
 
-	// import white list
-	whitelist := []string{}
-	openstackProjectWhitelist := r.OpenstackProjectWhitelist
-	if len(openstackProjectWhitelist) > 0 {
-		whitelist = strings.Split(openstackProjectWhitelist, ",")
+	// import watch list
+	watchlist := []string{}
+	openstackProjectWatchlist := r.OpenstackProjectWatchlist
+	if len(openstackProjectWatchlist) > 0 {
+		watchlist = strings.Split(openstackProjectWatchlist, ",")
 	}
 
 	for _, project := range projects {
 		projectName := project.Name
-		if !contains(whitelist, projectName) && len(whitelist) > 0 {
+		if !contains(watchlist, projectName) && len(watchlist) > 0 {
 			continue
 		}
 

--- a/discovery/pkg/openstack/reconciler.go
+++ b/discovery/pkg/openstack/reconciler.go
@@ -15,6 +15,7 @@ package openstack
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -48,9 +49,8 @@ type Reconciler struct {
 	ProjectLister
 
 	// BackendName is the name of the OpenStack cluster
-	BackendName     string
-	ClusterType     string
-	WatchedProjects string
+	BackendName string
+	ClusterType string
 	// GimbalKubeClient is the client of the Kubernetes cluster where Gimbal is running
 	GimbalKubeClient kubernetes.Interface
 	// Interval between reconciliation loops
@@ -68,7 +68,7 @@ type Endpoints struct {
 }
 
 // NewReconciler returns an OpenStack reconciler
-func NewReconciler(backendName, clusterType, watchedProjects string, gimbalKubeClient kubernetes.Interface, syncPeriod time.Duration, lbLister LoadBalancerLister,
+func NewReconciler(backendName, clusterType string, gimbalKubeClient kubernetes.Interface, syncPeriod time.Duration, lbLister LoadBalancerLister,
 	projectLister ProjectLister, log *logrus.Logger, queueWorkers int, metrics localmetrics.DiscovererMetrics) Reconciler {
 
 	return Reconciler{
@@ -80,7 +80,6 @@ func NewReconciler(backendName, clusterType, watchedProjects string, gimbalKubeC
 		Logger:             log,
 		Metrics:            metrics,
 		syncqueue:          sync.NewQueue(log, gimbalKubeClient, queueWorkers, metrics),
-		WatchedProjects:    watchedProjects,
 	}
 }
 
@@ -122,9 +121,8 @@ func (r *Reconciler) reconcile() {
 
 	// import white list
 	tmp := projects[:0]
-	watchedProjects := r.WatchedProjects
-	if watchedProjects != "" {
-		desireds := strings.Split(watchedProjects, ",")
+	if whitelist, ok := os.LookupEnv("PROJECT_WHITELIST"); ok && len(whitelist) > 0 {
+		desireds := strings.Split(whitelist, ",")
 		for _, project := range projects {
 			for _, desired := range desireds {
 				if desired == project.Name {
@@ -133,7 +131,7 @@ func (r *Reconciler) reconcile() {
 			}
 		}
 		projects = tmp
-		log.Info("sync load balancers on watched projects")
+		log.Info("sync whitelist load balancers")
 	} else {
 		log.Info("sync all load balancers")
 	}

--- a/discovery/pkg/openstack/reconciler.go
+++ b/discovery/pkg/openstack/reconciler.go
@@ -133,7 +133,7 @@ func (r *Reconciler) reconcile() {
 			}
 		}
 		projects = tmp
-		log.Info("sync load balancers  on watched projects")
+		log.Info("sync load balancers on watched projects")
 	} else {
 		log.Info("sync all load balancers")
 	}

--- a/discovery/pkg/openstack/reconciler_test.go
+++ b/discovery/pkg/openstack/reconciler_test.go
@@ -35,10 +35,10 @@ func TestListProjects(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to list projects: %v", err)
 	}
-	openstackProjectWhitelist := envOrFail(t, "OS_PROJECT_WHITELIST")
+	openstackProjectWatchlist := envOrFail(t, "OS_PROJECT_WHITELIST")
 
-	if openstackProjectWhitelist != "" && len(projects) > 0 {
-		watchedProjects := strings.Split(openstackProjectWhitelist, ",")
+	if openstackProjectWatchlist != "" && len(projects) > 0 {
+		watchedProjects := strings.Split(openstackProjectWatchlist, ",")
 		for _, project := range projects {
 			for _, watchedProject := range watchedProjects {
 				if watchedProject == project.Name {

--- a/discovery/pkg/openstack/reconciler_test.go
+++ b/discovery/pkg/openstack/reconciler_test.go
@@ -1,0 +1,82 @@
+// Copyright © 2018 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build openstack
+
+package openstack
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack"
+)
+
+func TestListProjects(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping openstack client integration tests")
+	}
+
+	c := identityClientFromEnv(t)
+	projects, err := c.ListProjects()
+	if err != nil {
+		t.Errorf("failed to list projects: %v", err)
+	}
+	openstackProjectWhitelist := envOrFail(t, "OS_PROJECT_WHITELIST")
+
+	if openstackProjectWhitelist != "" && len(projects) > 0 {
+		watchedProjects := strings.Split(openstackProjectWhitelist, ",")
+		for _, project := range projects {
+			for _, watchedProject := range watchedProjects {
+				if watchedProject == project.Name {
+					tmp = append(tmp, project)
+				}
+			}
+		}
+		projects = tmp
+	}
+
+	fmt.Println("Projects:", projects)
+}
+
+func identityClientFromEnv(t *testing.T) IdentityV3Client {
+	osAuthOptions := gophercloud.AuthOptions{
+		IdentityEndpoint: envOrFail(t, "OS_AUTH_URL"),
+		Username:         envOrFail(t, "OS_USERNAME"),
+		Password:         envOrFail(t, "OS_PASSWORD"),
+		TenantName:       envOrFail(t, "OS_TENANT_NAME"),
+		DomainName:       "Default",
+	}
+	osClient, err := openstack.AuthenticatedClient(osAuthOptions)
+	if err != nil {
+		t.Fatalf("failed to get openstack client: %v", err)
+	}
+
+	identity, err := openstack.NewIdentityV3(osClient)
+	if err != nil {
+		t.Errorf("Failed to create Identity V3 API client: %v", err)
+	}
+
+	return *identity
+}
+
+func envOrFail(t *testing.T, key string) string {
+	e := os.Getenv(key)
+	if e == "" {
+		t.Fatalf("The %q env var must be set", key)
+	}
+	return e
+}

--- a/docs/openstack-discoverer.md
+++ b/docs/openstack-discoverer.md
@@ -57,7 +57,7 @@ Arguments are available to customize the discoverer, most have defaults but othe
 | prometheus-listen-address | 8080 | The address to listen on for Prometheus HTTP requests
 | gimbal-client-qps | 5 | The maximum queries per second (QPS) that can be performed on the Gimbal Kubernetes API server
 | gimbal-client-burst | 10 | The maximum number of queries that can be performed on the Gimbal Kubernetes API server during a burst
-| openstack-project-whitelist | "" | The whitelist of projects that should be reconciled. If empty, load balancers across all projects will be reconciled.
+| openstack-project-whitelist | "" | List of projects to be watched for reconcilation. If empty, load balancers across all projects will be reconciled. This whitelist should be comma separated list. e.g) --openstack-project-whitelist=project1,project2...
 
 ### Credentials
 

--- a/docs/openstack-discoverer.md
+++ b/docs/openstack-discoverer.md
@@ -57,6 +57,7 @@ Arguments are available to customize the discoverer, most have defaults but othe
 | prometheus-listen-address | 8080 | The address to listen on for Prometheus HTTP requests
 | gimbal-client-qps | 5 | The maximum queries per second (QPS) that can be performed on the Gimbal Kubernetes API server
 | gimbal-client-burst | 10 | The maximum number of queries that can be performed on the Gimbal Kubernetes API server during a burst
+| openstack-project-whitelist | "" | The whitelist of projects that should be reconciled. If empty, load balancers across all projects will be reconciled.
 
 ### Credentials
 

--- a/docs/openstack-discoverer.md
+++ b/docs/openstack-discoverer.md
@@ -57,7 +57,7 @@ Arguments are available to customize the discoverer, most have defaults but othe
 | prometheus-listen-address | 8080 | The address to listen on for Prometheus HTTP requests
 | gimbal-client-qps | 5 | The maximum queries per second (QPS) that can be performed on the Gimbal Kubernetes API server
 | gimbal-client-burst | 10 | The maximum number of queries that can be performed on the Gimbal Kubernetes API server during a burst
-| openstack-project-whitelist | "" | List of projects to be watched for reconcilation. If empty, load balancers across all projects will be reconciled. This whitelist should be comma separated list. e.g) --openstack-project-whitelist=project1,project2...
+| openstack-project-watchlist | "" | List of projects to be watched for reconcilation. If empty, load balancers across all projects will be reconciled. This watchlist should be comma separated list. e.g) --openstack-project-watchlist=project1,project2...
 
 ### Credentials
 


### PR DESCRIPTION
I tried to deploy OpenStack Discoverer, but sync cycle was too long on a OpenStack cluster which has many projects.

My suggestion is to implement whitelist for rapid sync cycle.
```
$ kubectl logs openstack-discoverer-5556b6dcbc-ptj6n -n gimbal-discovery | grep 'dreco-001/openstack-626c5bf1-3cf8-438a-b6a1-e20419126eee'

time="2018-10-28T22:20:33Z" level=info msg="Successfully handled: update service 'dreco-001/openstack-626c5bf1-3cf8-438a-b6a1-e20419126eee'"
time="2018-10-28T22:51:58Z" level=info msg="Successfully handled: update endpoints 'dreco-001/openstack-626c5bf1-3cf8-438a-b6a1-e20419126eee'"
time="2018-10-28T22:51:59Z" level=info msg="Successfully handled: update service 'dreco-001/openstack-626c5bf1-3cf8-438a-b6a1-e20419126eee'"
time="2018-10-28T23:23:19Z" level=info msg="Successfully handled: update endpoints 'dreco-001/openstack-626c5bf1-3cf8-438a-b6a1-e20419126eee'"
time="2018-10-28T23:54:43Z" level=info msg="Successfully handled: update service 'dreco-001/openstack-626c5bf1-3cf8-438a-b6a1-e20419126eee'"
time="2018-10-28T23:54:43Z" level=info msg="Successfully handled: update endpoints 'dreco-001/openstack-626c5bf1-3cf8-438a-b6a1-e20419126eee'"
```

issue: #241 

Signed-off-by: Hiroaki Morikawa <hmorikaw@yahoo-corp.jp>