### PR TITLE
Remove alpine from base images & build images. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.9.x
+  - 1.12.x
 
 script:
 - cd discovery && make ci

--- a/discovery/Dockerfile
+++ b/discovery/Dockerfile
@@ -1,8 +1,9 @@
-FROM alpine:3.6
+FROM debian:stretch-slim
 LABEL maintainer="Steve Sloka <slokas@vmware.com>"
 
-RUN apk add --update ca-certificates && \
-  rm -rf /var/cache/apk/*
+RUN apt-get update && apt-get install -y ca-certificates && \
+  apt-get clean autoclean && apt-get autoremove -y && \
+  rm -rf /var/lib/{apt,dpkg,cache,log}/
 
 ADD _output/bin/linux/amd64/kubernetes-discoverer /kubernetes-discoverer
 ADD _output/bin/linux/amd64/openstack-discoverer /openstack-discoverer

--- a/discovery/Makefile
+++ b/discovery/Makefile
@@ -40,7 +40,7 @@ GOARCH = $(word 2, $(platform_temp))
 
 IMAGE := $(REGISTRY)/gimbal-discoverer
 
-BUILD_IMAGE ?= gcr.io/heptio-images/golang:1.9-alpine3.6
+BUILD_IMAGE ?= golang:1.12-stretch
 
 PARENTDIR ?= $(dirname "$(pwd)")
 

--- a/discovery/hack/build.sh
+++ b/discovery/hack/build.sh
@@ -40,6 +40,7 @@ if [ -z "${VERSION}" ]; then
 fi
 
 export CGO_ENABLED=0
+export XDG_CACHE_HOME=/tmp/.cache
 
 # GIT_SHA=$(git --git-dir=/git describe --tags --always)
 # GIT_DIRTY=$(git --git-dir=/git status --porcelain 2> /dev/null)
@@ -55,7 +56,7 @@ LDFLAGS="${LDFLAGS} -X ${PKG}/pkg/buildinfo.GitSHA=${GIT_SHA}"
 LDFLAGS="${LDFLAGS} -X ${PKG}/pkg/buildinfo.GitTreeState=${GIT_TREE_STATE}"
 
 if [[ -z "${OUTPUT_DIR:-}" ]]; then
-  OUTPUT_DIR=.
+  OUTPUT_DIR=${PWD}
 fi
 OUTPUT=${OUTPUT_DIR}/${BIN}
 if [[ "${GOOS}" = "windows" ]]; then

--- a/discovery/hack/test.sh
+++ b/discovery/hack/test.sh
@@ -19,6 +19,7 @@ set -o nounset
 set -o pipefail
 
 export CGO_ENABLED=0
+export XDG_CACHE_HOME=/tmp/.cache
 
 TARGETS=$(for d in "$@"; do echo ./$d/...; done)
 

--- a/discovery/hack/verify-all.sh
+++ b/discovery/hack/verify-all.sh
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 HACK_DIR=$(dirname "${BASH_SOURCE}")
+export XDG_CACHE_HOME=/tmp/.cache
 
 echo "Running all verification scripts"
 

--- a/discovery/hack/verify-fmt.sh
+++ b/discovery/hack/verify-fmt.sh
@@ -15,9 +15,10 @@
 # limitations under the License.
 
 HACK_DIR=$(dirname "${BASH_SOURCE}")
+export XDG_CACHE_HOME=/tmp/.cache
 
 echo "Verifying gofmt"
-files=$(gofmt -l -s $(find . -type f -name "*.go" -not -path "./vendor/*" -not -path "./pkg/generated/*" -not -name "zz_generated*"))
+files=$(gofmt -l -s $(find . -type f -name "*.go" -not -path "./vendor/*" -not -path "./pkg/generated/*" -not -name "zz_generated*" -not -path "./.go/*"))
 if [[ -n "${files}" ]]; then
   echo "The following files need gofmt updating - please run 'make update'"
   echo "${files}"

--- a/discovery/pkg/sync/queue_test.go
+++ b/discovery/pkg/sync/queue_test.go
@@ -102,12 +102,12 @@ func TestQueueServicesMetrics(t *testing.T) {
 		expectedErrorCounter   float64
 	}{
 		{
-			name: "successfull replication",
+			name:                   "successfull replication",
 			expectedTimestampGauge: float64(now.Unix()),
 			expectedErrorCounter:   float64(-1), // no error, so error counter is not initialized
 		},
 		{
-			name: "failed to replicate service",
+			name:                   "failed to replicate service",
 			expectedTimestampGauge: float64(-1), // failed to sync resource, so timestamp is not initialized
 			expectedErrorCounter:   float64(queueMaxRetries),
 			apiServerError:         errors.New("api server error"),
@@ -155,13 +155,13 @@ func TestQueueEndpointsMetrics(t *testing.T) {
 		expectedReplicatedEndpointsGauge float64
 	}{
 		{
-			name: "successfull replication",
+			name:                             "successfull replication",
 			expectedTimestampGauge:           float64(now.Unix()),
 			expectedErrorCounter:             float64(-1), // no error, so error counter is not initialized
 			expectedReplicatedEndpointsGauge: float64(2),
 		},
 		{
-			name: "failed to replicate endpoints resource",
+			name:                             "failed to replicate endpoints resource",
 			expectedTimestampGauge:           float64(-1), // failed to sync resource, so timestamp is not initialized
 			expectedErrorCounter:             float64(queueMaxRetries),
 			expectedReplicatedEndpointsGauge: float64(-1), // failed to replicate, so gauge is not initialized

--- a/discovery/pkg/translator/translator_test.go
+++ b/discovery/pkg/translator/translator_test.go
@@ -137,7 +137,7 @@ func TestAddLabels(t *testing.T) {
 			expected: map[string]string{
 				"gimbal.heptio.com/backend": "test01",
 				"gimbal.heptio.com/service": "service01",
-				"key1": "value1",
+				"key1":                      "value1",
 			},
 		},
 		{
@@ -147,12 +147,12 @@ func TestAddLabels(t *testing.T) {
 			podLabels: map[string]string{
 				"gimbal.heptio.com/backend": "badBackendName",
 				"gimbal.heptio.com/service": "badService",
-				"key1": "value1",
+				"key1":                      "value1",
 			},
 			expected: map[string]string{
 				"gimbal.heptio.com/backend": "test01",
 				"gimbal.heptio.com/service": "service01",
-				"key1": "value1",
+				"key1":                      "value1",
 			},
 		},
 		{


### PR DESCRIPTION
Fixes #259 by removing alpine and switching to debian-slim. Also, fixes build scripts for go1.12

Signed-off-by: Steve Sloka <steve@stevesloka.com>