### PR TITLE
Add prestop hook & readiness probe to Envoy

### DIFF
--- a/deployment/contour/03-contour.yaml
+++ b/deployment/contour/03-contour.yaml
@@ -35,12 +35,10 @@ spec:
         - 0.0.0.0
         - --xds-port
         - $(CONTOUR_SERVICE_PORT)
-         - --envoy-service-http-port
-        - 80
-        - --envoy-service-https-port
-        - 443
+        - --envoy-service-http-port=80
+        - --envoy-service-https-port=443
         command: ["contour"]
-        image: gcr.io/heptio-images/contour:v0.10.0
+        image: gcr.io/heptio-images/contour:v0.9.0
         imagePullPolicy: Always
         name: contour
         ports:

--- a/deployment/contour/03-envoy.yaml
+++ b/deployment/contour/03-envoy.yaml
@@ -34,7 +34,7 @@ spec:
         - node0
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy-alpine:v1.9.0
+        image: docker.io/envoyproxy/envoy:v1.9.0
         imagePullPolicy: IfNotPresent
         name: envoy
         ports:
@@ -46,9 +46,19 @@ spec:
           hostPort: 443
           name: https
           protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8002
+          initialDelaySeconds: 3
+          periodSeconds: 3
         volumeMounts:
           - name: contour-config
             mountPath: /config
+        lifecycle:
+          preStop:
+            exec:
+              command: ["wget", "-qO-", "--post-data=''", "http://localhost:9001/healthcheck/fail"] 
       - name: statsd-sink
         image: prom/statsd-exporter:v0.6.0
         command: 


### PR DESCRIPTION
Fixes #144 by adding a preStop hook as well as a readiness probe to Envoy.

Signed-off-by: Steve Sloka <slokas@vmware.com>